### PR TITLE
Handle empty/invalid repo directory in ensureCloned

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -35,7 +35,8 @@ private def shellQuote (s : String) : String :=
 private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : Bool)
     (continuesFrom : Option String := none)
     (series : Option String := none)
-    (cancelToken : Option Std.CancellationToken := none) : IO (String × Bool) := do
+    (cancelToken : Option Std.CancellationToken := none)
+    (interactive : Bool := true) : IO (String × Bool) := do
   IO.println s!"=== Task {idx}: {task.fork} ({repr task.mode}) ==="
   -- Record this run in the task store
   let taskId ← TaskStore.generateId
@@ -69,7 +70,7 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
   IO.println "  Token ready"
   -- 2. Clone / update repo
   IO.println s!"Cloning/updating {task.fork}..."
-  let repoPath ← Repo.ensureCloned task.fork task.upstream
+  let repoPath ← Repo.ensureCloned task.fork task.upstream interactive
   IO.println s!"  Repo at {repoPath}"
   -- 3. Start MCP server (runs in this process, outside the sandbox)
   let serverState : Server.State := {
@@ -533,7 +534,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
       try
         let (taskId, usageLimitHit) ← runTask cfg task 0 debug
           (continuesFrom := entry.continuesFrom) (series := entry.series)
-          (cancelToken := some taskToken)
+          (cancelToken := some taskToken) (interactive := false)
         currentTaskToken.atomically (·.set none)
         if ← taskToken.isCancelled then
           Queue.saveEntry { entry with status := .cancelled, taskId := some taskId }

--- a/Orchestra/Repo.lean
+++ b/Orchestra/Repo.lean
@@ -33,8 +33,10 @@ def splitRepo (s : String) : IO (String × String) := do
 /--
 Ensure the fork is cloned and the upstream remote is configured.
 Returns the path to the local repository.
+When `interactive` is false (e.g. queue mode), user prompts are suppressed and
+an error is thrown instead.
 -/
-def ensureCloned (fork upstream : String) : IO System.FilePath := do
+def ensureCloned (fork upstream : String) (interactive : Bool := true) : IO System.FilePath := do
   let (forkOwner, forkRepo) ← splitRepo fork
   let base ← workDir
   let repoPath := base / forkOwner / forkRepo
@@ -42,6 +44,7 @@ def ensureCloned (fork upstream : String) : IO System.FilePath := do
     let entries ← repoPath.readDir
     if entries.isEmpty then
       -- Empty directory left over from a failed clone: remove and retry
+      IO.println s!"  Directory '{repoPath}' is empty; removing and re-cloning..."
       IO.FS.removeDirAll repoPath
       IO.FS.createDirAll repoPath
       runGit' #["clone", s!"https://github.com/{fork}.git", repoPath.toString]
@@ -56,6 +59,8 @@ def ensureCloned (fork upstream : String) : IO System.FilePath := do
         catch _ =>
           pure false
       if !isGitRepo then
+        if !interactive then
+          throw (IO.userError s!"Directory '{repoPath}' exists but is not a valid git repository. Remove it manually and try again.")
         IO.eprint s!"Directory '{repoPath}' exists but is not a valid git repository.\nDelete it and re-clone? [y/N] "
         let stdin ← IO.getStdin
         let answer := (← stdin.getLine).trimAscii.toString.toLower


### PR DESCRIPTION
Fixes #2

## Changes

- **Empty directory**: If `ensureCloned` finds the repo path exists but is empty (e.g., left over from a previously failed clone), it automatically removes the directory and re-clones.
- **Non-empty non-git directory**: If the directory exists, is non-empty, but is not a valid git repository, the user is prompted to confirm deletion and re-clone. If they decline, a clear error message tells them to remove it manually.