### PR TITLE
Add file logging for agent runs in newline-delimited JSON format

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -162,11 +162,18 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
         let suffix := if attempt == 0 then "" else s!".retry{attempt}"
         pure (some ((← TaskStore.tasksDir) / s!"{taskId}{suffix}.debug.jsonl"))
       else pure none
+    -- Structured JSON log: ~/.agent/logs/{fork}/{taskId}.log (always)
+    let taskLogFile : Option System.FilePath ← do
+      match ← IO.getEnv "HOME" with
+      | none => pure none
+      | some home =>
+        let suffix := if attempt == 0 then "" else s!".retry{attempt}"
+        pure (some (System.FilePath.mk home / ".agent" / "logs" / task.fork / s!"{taskId}{suffix}.log"))
     let result ← Sandbox.launchAgent agentDef repoPath prompt port token
       (debug := debug) (pluginDirs := appConfig.pluginDirs) (memoryDirs := memoryDirs)
       (subAgent := task.agent) (model := task.model) (systemPrompt := systemPrompt)
       (resume := resume) (budget := task.budget.getD 4.0) (cancelToken := cancelToken)
-      (extraEnv := apiKeyEnv) (debugLogFile := debugLogFile)
+      (extraEnv := apiKeyEnv) (debugLogFile := debugLogFile) (logFile := taskLogFile)
     IO.println s!"  Agent exited with code {result.exitCode}"
     sessionId := result.sessionId
     if result.wasCancelled then

--- a/Orchestra/Sandbox.lean
+++ b/Orchestra/Sandbox.lean
@@ -46,7 +46,8 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
     (resume : Option String := none)
     (budget : Float := 4.0)
     (cancelToken : Option Std.CancellationToken := none)
-    (debugLogFile : Option System.FilePath := none) : IO LaunchResult := do
+    (debugLogFile : Option System.FilePath := none)
+    (logFile : Option System.FilePath := none) : IO LaunchResult := do
   -- Run agent-specific MCP setup (writes config files, returns extra env vars)
   let (mcpContext, agentEnv) ← agentDef.setupMcp serverPort model systemPrompt
   let paths := agentDef.sandboxPaths
@@ -147,6 +148,13 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
   let debugHandle : Option IO.FS.Handle ← match debugLogFile with
     | none      => pure none
     | some path => some <$> IO.FS.Handle.mk path .write
+  -- Open the structured JSON log file (one per task, always created when path is given)
+  let logHandle : Option IO.FS.Handle ← match logFile with
+    | none      => pure none
+    | some path =>
+      if let some dir := path.parent then
+        IO.FS.createDirAll dir
+      some <$> IO.FS.Handle.mk path .write
   -- Stream stdout, parse events and format for display; capture session ID if emitted
   let sessionIdRef ← IO.mkRef (none : Option String)
   let outTask ← IO.asTask (prio := .dedicated) do
@@ -165,6 +173,10 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
           sessionIdRef.set (some sid)
         out.putStrLn (StreamFormat.format event)
         out.flush
+        -- Write the parsed event as a JSON line to the structured log
+        if let some h := logHandle then
+          h.putStrLn (Lean.Json.compress (Lean.ToJson.toJson event))
+          h.flush
   -- Stream stderr to console and capture it for usage-limit detection
   let stderrRef ← IO.mkRef ""
   let errTask ← IO.asTask (prio := .dedicated) do

--- a/Orchestra/StreamFormat.lean
+++ b/Orchestra/StreamFormat.lean
@@ -1,6 +1,6 @@
 import Lean.Data.Json
 
-open Lean (Json)
+open Lean (Json ToJson)
 
 namespace Orchestra.StreamFormat
 
@@ -39,6 +39,37 @@ inductive Event where
   | result (subtype : String) (numTurns : Option Nat) (durationMs : Option Nat)
             (costUsd : Option Json) (res : String)
   | unknown (type : String)
+
+-- Serialisation
+
+instance : ToJson ContentItem where
+  toJson
+    | .thinking t    => Json.mkObj [("type", "thinking"), ("text", t)]
+    | .toolUse n inp => Json.mkObj [("type", "tool_use"), ("name", n), ("input", inp)]
+    | .text t        => Json.mkObj [("type", "text"), ("text", t)]
+
+instance : ToJson Event where
+  toJson
+    | .init sid model =>
+      Json.mkObj [("type", "init"), ("session_id", sid), ("model", model)]
+    | .system sub =>
+      Json.mkObj [("type", "system"), ("subtype", sub)]
+    | .assistant ci =>
+      Json.mkObj [("type", "assistant"), ("item", ToJson.toJson ci)]
+    | .toolResult stdout stderr =>
+      Json.mkObj [("type", "tool_result"), ("stdout", stdout), ("stderr", stderr)]
+    | .result sub numTurns durationMs costUsd res =>
+      let fields : List (String × Json) := [
+        ("type",    "result"),
+        ("subtype", sub),
+        ("result",  res)
+      ]
+      let fields := match numTurns  with | some n => fields ++ [("num_turns",   ToJson.toJson n)]   | none => fields
+      let fields := match durationMs with | some n => fields ++ [("duration_ms", ToJson.toJson n)]   | none => fields
+      let fields := match costUsd   with | some v => fields ++ [("total_cost_usd", v)] | none => fields
+      Json.mkObj fields
+    | .unknown t =>
+      Json.mkObj [("type", "unknown"), ("event_type", t)]
 
 -- Parsing
 


### PR DESCRIPTION
## Summary

- Adds `ToJson` instances for `ContentItem` and `Event` in `StreamFormat.lean`, enabling typed events to be serialised back to JSON
- Adds a `logFile : Option System.FilePath` parameter to `Sandbox.launchAgent`; when set, each parsed event is written as a compressed JSON line using the new `ToJson` instances
- In `runTask` (Main.lean), computes the log path `~/.agent/logs/{fork}/{taskId}.log` and passes it to `launchAgent`, so every run is logged unconditionally in newline-delimited JSON

## Test plan

- [ ] Build passes (`lake build`)
- [ ] Run a task and verify a `.log` file is created at `~/.agent/logs/<fork>/<taskId>.log`
- [ ] Confirm the log file contains one JSON object per line, each representing a parsed `Event`
- [ ] Retry runs produce separate log files with `.retry1` etc. suffixes

Closes #4