### PR TITLE
Allow listeners to define a list of actions per event (task sequences)

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -681,9 +681,10 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
           let state  ← Listener.loadListenerState lcfg.name
           let events ← Listener.pollSource lcfg.source state appConfig.pat appConfig.authorizedUsers
           for ev in (events : Array (String × List (String × String))) do
-            let qentry ← Listener.buildQueueEntry lcfg.action ev.2
-            Queue.saveEntry qentry
-            IO.println s!"  Listener '{lcfg.name}': queued entry {qentry.id}"
+            for action in lcfg.actions do
+              let qentry ← Listener.buildQueueEntry action ev.2
+              Queue.saveEntry qentry
+              IO.println s!"  Listener '{lcfg.name}': queued entry {qentry.id}"
           -- Update state: record processed IDs and last-checked timestamp
           let newIds   := events.filterMap (fun ev =>
             if (ev.1 : String).isEmpty then none else some ev.1)

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -179,14 +179,16 @@ instance : FromJson ActionConfig where
 structure ListenerConfig where
   name            : String
   source          : SourceConfig
-  action          : ActionConfig
+  /-- The list of actions to enqueue (in order) when an event fires.
+      Tasks are enqueued sequentially and the FIFO queue ensures they run in order. -/
+  actions         : List ActionConfig
   intervalSeconds : Nat := 60
 
 instance : ToJson ListenerConfig where
   toJson l := Json.mkObj [
     ("name",             l.name),
     ("source",           ToJson.toJson l.source),
-    ("action",           ToJson.toJson l.action),
+    ("actions",          ToJson.toJson l.actions),
     ("interval_seconds", l.intervalSeconds)
   ]
 
@@ -194,9 +196,15 @@ instance : FromJson ListenerConfig where
   fromJson? j := do
     let name            ← j.getObjValAs? String "name"
     let source          ← j.getObjValAs? SourceConfig "source"
-    let action          ← j.getObjValAs? ActionConfig "action"
+    -- Accept both `"actions": [...]` (new) and `"action": {...}` (legacy single-action).
+    let actions ←
+      match j.getObjValAs? (List ActionConfig) "actions" |>.toOption with
+      | some as => pure as
+      | none    => do
+          let a ← j.getObjValAs? ActionConfig "action"
+          pure [a]
     let intervalSeconds  := j.getObjValAs? Nat "interval_seconds" |>.toOption |>.getD 60
-    return { name, source, action, intervalSeconds }
+    return { name, source, actions, intervalSeconds }
 
 -- Listener state
 

--- a/Test/ListenerConfigTest.lean
+++ b/Test/ListenerConfigTest.lean
@@ -160,3 +160,66 @@ def appConfigDefaultAuthorizedUsers : Test := do
   | .ok cfg =>
     TestM.assertEqual cfg.authorizedUsers ([] : List String)
       (msg := "authorizedUsers default empty")
+
+@[test]
+def listenerConfigSingleActionBackwardCompat : Test := do
+  -- Old format with a single `action` field should still parse correctly.
+  let json := r#"
+    {"name": "my-listener",
+     "source": {"type": "github-comments", "fork": "org/repo", "trigger": "@bot"},
+     "action": {"mode": "fork", "prompt_template": "do something"}}
+  "#
+  match Json.parse json >>= FromJson.fromJson? (α := ListenerConfig) with
+  | .error e => TestM.fail s!"single action backward compat: {e}"
+  | .ok cfg =>
+    TestM.assertEqual cfg.name "my-listener" (msg := "name")
+    TestM.assertEqual cfg.actions.length 1 (msg := "actions length")
+    match cfg.actions with
+    | [a] => TestM.assertEqual a.promptTemplate "do something" (msg := "promptTemplate")
+    | _   => TestM.fail "expected exactly one action"
+
+@[test]
+def listenerConfigActionsListNewFormat : Test := do
+  -- New format with an `actions` list should parse all entries.
+  let json := r#"
+    {"name": "multi-action",
+     "source": {"type": "github-comments", "fork": "org/repo", "trigger": "@bot"},
+     "actions": [
+       {"mode": "fork", "prompt_template": "implement {{body}}"},
+       {"mode": "fork", "prompt_template": "review the changes", "series": "review-{{issue_number}}"}
+     ]}
+  "#
+  match Json.parse json >>= FromJson.fromJson? (α := ListenerConfig) with
+  | .error e => TestM.fail s!"actions list new format: {e}"
+  | .ok cfg =>
+    TestM.assertEqual cfg.name "multi-action" (msg := "name")
+    TestM.assertEqual cfg.actions.length 2 (msg := "actions length")
+    match cfg.actions with
+    | [a1, a2] =>
+      TestM.assertEqual a1.promptTemplate "implement {{body}}" (msg := "actions[0].promptTemplate")
+      TestM.assertEqual a2.promptTemplate "review the changes" (msg := "actions[1].promptTemplate")
+      TestM.assertEqual a2.series (some "review-{{issue_number}}") (msg := "actions[1].series")
+    | _ => TestM.fail "expected exactly two actions"
+
+@[test]
+def listenerConfigActionsRoundTrip : Test := do
+  -- Round-trip: toJson >> fromJson should preserve the actions list.
+  let cfg : ListenerConfig := {
+    name   := "rt-listener"
+    source := .githubComments [{ upstream := "org/repo", fork := "org/repo" }] [] "@bot" []
+    actions := [
+      { mode := .fork, promptTemplate := "first task" },
+      { mode := .fork, promptTemplate := "second task", series := some "s-{{issue_number}}" }
+    ]
+  }
+  match FromJson.fromJson? (ToJson.toJson cfg) (α := ListenerConfig) with
+  | .error e => TestM.fail s!"ListenerConfig round-trip: {e}"
+  | .ok got =>
+    TestM.assertEqual got.name "rt-listener" (msg := "name")
+    TestM.assertEqual got.actions.length 2 (msg := "actions length")
+    match got.actions with
+    | [a1, a2] =>
+      TestM.assertEqual a1.promptTemplate "first task" (msg := "actions[0].promptTemplate")
+      TestM.assertEqual a2.promptTemplate "second task" (msg := "actions[1].promptTemplate")
+      TestM.assertEqual a2.series (some "s-{{issue_number}}") (msg := "actions[1].series")
+    | _ => TestM.fail "expected exactly two actions"

--- a/examples/listeners/github-issues.json
+++ b/examples/listeners/github-issues.json
@@ -8,12 +8,14 @@
     "labels": ["orchestra"],
     "authorized_users": ["alice", "bob"]
   },
-  "action": {
-    "upstream": "{{upstream}}",
-    "fork": "{{fork}}",
-    "mode": "pr",
-    "prompt_template": "A new GitHub issue has been filed that is labelled for automated handling.\n\nIssue #{{issue_number}}: {{title}}\nURL: {{url}}\n\n{{body}}\n\nPlease investigate and implement a fix or feature as described in the issue. Open a pull request with your changes.",
-    "series": "issue-{{issue_number}}"
-  },
+  "actions": [
+    {
+      "upstream": "{{upstream}}",
+      "fork": "{{fork}}",
+      "mode": "pr",
+      "prompt_template": "A new GitHub issue has been filed that is labelled for automated handling.\n\nIssue #{{issue_number}}: {{title}}\nURL: {{url}}\n\n{{body}}\n\nPlease investigate and implement a fix or feature as described in the issue. Open a pull request with your changes.",
+      "series": "issue-{{issue_number}}"
+    }
+  ],
   "interval_seconds": 300
 }

--- a/examples/listeners/implement-review-cycle.json
+++ b/examples/listeners/implement-review-cycle.json
@@ -1,0 +1,35 @@
+{
+  "name": "implement-review-cycle",
+  "source": {
+    "type": "github-issues",
+    "repos": [
+      {"upstream": "upstream-org/upstream-repo", "fork": "your-org/upstream-repo"}
+    ],
+    "labels": ["orchestra"],
+    "authorized_users": ["alice", "bob"]
+  },
+  "actions": [
+    {
+      "upstream": "{{upstream}}",
+      "fork": "{{fork}}",
+      "mode": "pr",
+      "prompt_template": "A new GitHub issue has been filed.\n\nIssue #{{issue_number}}: {{title}}\nURL: {{url}}\n\n{{body}}\n\nPlease implement a fix or feature as described in the issue and open a pull request.",
+      "series": "issue-{{issue_number}}"
+    },
+    {
+      "upstream": "{{upstream}}",
+      "fork": "{{fork}}",
+      "mode": "pr",
+      "prompt_template": "Review the pull request you just opened for issue #{{issue_number}}. Check for correctness, style, and completeness. Leave review comments if needed.",
+      "series": "review-{{issue_number}}"
+    },
+    {
+      "upstream": "{{upstream}}",
+      "fork": "{{fork}}",
+      "mode": "pr",
+      "prompt_template": "Address any review comments left on the pull request for issue #{{issue_number}} and push updated commits.",
+      "series": "issue-{{issue_number}}"
+    }
+  ],
+  "interval_seconds": 300
+}

--- a/examples/listeners/pr-issue-comments.json
+++ b/examples/listeners/pr-issue-comments.json
@@ -8,12 +8,14 @@
     "trigger": "@orchestra",
     "authorized_users": []
   },
-  "action": {
-    "upstream": "{{upstream}}",
-    "fork": "{{fork}}",
-    "mode": "fork",
-    "prompt_template": "A comment has been left on issue/PR #{{issue_number}}.\n\nAuthor: {{author}}\nURL: {{url}}\n\n{{body}}\n\nPlease read the comment and take the appropriate action.",
-    "series": "issue-{{issue_number}}"
-  },
+  "actions": [
+    {
+      "upstream": "{{upstream}}",
+      "fork": "{{fork}}",
+      "mode": "fork",
+      "prompt_template": "A comment has been left on issue/PR #{{issue_number}}.\n\nAuthor: {{author}}\nURL: {{url}}\n\n{{body}}\n\nPlease read the comment and take the appropriate action.",
+      "series": "issue-{{issue_number}}"
+    }
+  ],
   "interval_seconds": 120
 }

--- a/examples/listeners/pr-reviews.json
+++ b/examples/listeners/pr-reviews.json
@@ -8,13 +8,15 @@
     "labels": ["orchestra"],
     "authorized_users": []
   },
-  "action": {
-    "upstream": "{{upstream}}",
-    "fork": "{{fork}}",
-    "mode": "fork",
-    "prompt_template": "A reviewer has left feedback on pull request #{{pr_number}} (\"{{pr_title}}\").\n\nReviewer: {{reviewer}}\nURL: {{url}}\n\n{{body}}\n\nPlease address the reviewer's comments and push updated commits to the pull request branch.",
-    "series": "pr-{{pr_number}}",
-    "budget": 2.0
-  },
+  "actions": [
+    {
+      "upstream": "{{upstream}}",
+      "fork": "{{fork}}",
+      "mode": "fork",
+      "prompt_template": "A reviewer has left feedback on pull request #{{pr_number}} (\"{{pr_title}}\").\n\nReviewer: {{reviewer}}\nURL: {{url}}\n\n{{body}}\n\nPlease address the reviewer's comments and push updated commits to the pull request branch.",
+      "series": "pr-{{pr_number}}",
+      "budget": 2.0
+    }
+  ],
   "interval_seconds": 120
 }

--- a/examples/listeners/shell-source.json
+++ b/examples/listeners/shell-source.json
@@ -5,12 +5,14 @@
     "command": "/path/to/your/source-script.sh",
     "args": []
   },
-  "action": {
-    "upstream": "upstream-org/upstream-repo",
-    "fork": "your-org/upstream-repo",
-    "mode": "fork",
-    "prompt_template": "{{output}}",
-    "series": "shell-tasks"
-  },
+  "actions": [
+    {
+      "upstream": "upstream-org/upstream-repo",
+      "fork": "your-org/upstream-repo",
+      "mode": "fork",
+      "prompt_template": "{{output}}",
+      "series": "shell-tasks"
+    }
+  ],
   "interval_seconds": 600
 }


### PR DESCRIPTION
Closes #17

## Summary

- `ListenerConfig.action` (single) is replaced by `ListenerConfig.actions` (list), so multiple tasks can be enqueued sequentially whenever a listener event fires
- Backward compatibility is preserved: configs using the old `"action"` field still parse correctly and are treated as a single-element list
- The FIFO queue daemon already processes tasks one at a time, so sequentially-enqueued actions naturally run in order

## Changes

- **`Orchestra/Listener.lean`**: replace `action : ActionConfig` with `actions : List ActionConfig`; update `ToJson`/`FromJson` with backward-compat fallback to `"action"`
- **`Main.lean`**: iterate over `lcfg.actions` when building queue entries for each event
- **`Test/ListenerConfigTest.lean`**: add three new tests — single-action backward compat, new list format, and round-trip
- **`examples/listeners/`**: update all existing examples to use the new `"actions"` field; add `implement-review-cycle.json` showing the implement → review → implement-review use case from the issue

## Test plan

- [ ] `lake test` passes (19/19 tests, including 3 new ones)
- [ ] Old listener configs using `"action"` continue to load and work
- [ ] New configs with `"actions": [...]` enqueue one queue entry per action per event, in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)