### PR TITLE
Add extraPorts configuration at task and listener level

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -151,6 +151,7 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
       (debug := debug) (pluginDirs := appConfig.pluginDirs) (memoryDirs := memoryDirs)
       (subAgent := task.agent) (model := task.model) (systemPrompt := systemPrompt)
       (resume := resume) (budget := task.budget.getD 4.0) (cancelToken := cancelToken)
+      (extraPorts := task.extraPorts)
     IO.println s!"  Agent exited with code {result.exitCode}"
     sessionId := result.sessionId
     if result.wasCancelled then
@@ -453,6 +454,7 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
         continuesFrom, series
         configPath
         budget       := budgetFlag.orElse (fun _ => task.budget)
+        extraPorts   := task.extraPorts
       }
       Queue.saveEntry entry
       IO.println entry.id
@@ -574,6 +576,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         model        := entry.model
         budget       := entry.budget
         memory       := entry.memory
+        extraPorts   := entry.extraPorts
       }
       let cfg ← match entry.configPath with
         | none    => pure appConfig
@@ -893,6 +896,7 @@ private def queueRetryHandler (p : Parsed) : IO UInt32 := do
       continuesFrom
       series       := entry.series
       configPath   := entry.configPath
+      extraPorts   := entry.extraPorts
     }
     Queue.saveEntry newEntry
     IO.println newEntry.id

--- a/Orchestra/AgentDef.lean
+++ b/Orchestra/AgentDef.lean
@@ -38,6 +38,8 @@ structure AgentDef where
   command : String
   /-- Filesystem paths the agent needs inside the sandbox. -/
   sandboxPaths : SandboxPaths
+  /-- TCP ports the agent backend requires in addition to the MCP server port. -/
+  ports : List UInt16 := [443]
   /-- Set up agent-specific infrastructure before launch (e.g., write MCP config files).
       Receives the MCP server port, optional model override, and optional appended system prompt.
       Returns a context string (passed to buildArgs, extractSessionId, and cleanup)

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -62,6 +62,8 @@ structure Task where
   budget : Option Float := none
   /-- Which memory directories to make available to the agent. Defaults to `both`. -/
   memory : MemoryMode := .both
+  /-- Extra TCP ports to allow in the sandbox, in addition to what the agent backend requires. -/
+  extraPorts : List Nat := []
 deriving Repr, Inhabited
 
 instance : FromJson Task where
@@ -76,7 +78,9 @@ instance : FromJson Task where
     let model := j.getObjValAs? String "model" |>.toOption
     let budget := j.getObjValAs? Float "budget" |>.toOption
     let memory := j.getObjValAs? MemoryMode "memory" |>.toOption |>.getD .both
-    return { upstream, fork, mode, prompt, agent, systemPrompt, backend, model, budget, memory }
+    let extraPorts := j.getObjValAs? (List Nat) "extra_ports" |>.toOption |>.getD []
+    return { upstream, fork, mode, prompt, agent, systemPrompt, backend, model, budget, memory,
+             extraPorts }
 
 structure AppConfig where
   appId : Nat

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -70,6 +70,8 @@ structure ActionConfig where
   budget         : Option Float  := none
   /-- Which memory directories to make available to the agent. Defaults to `both`. -/
   memory         : MemoryMode    := .both
+  /-- Extra TCP ports to allow in the sandbox, in addition to what the agent backend requires. -/
+  extraPorts     : List Nat      := []
 
 instance : ToJson ActionConfig where
   toJson a :=
@@ -87,6 +89,7 @@ instance : ToJson ActionConfig where
     let fields := if let some s := a.systemPrompt then fields ++ [("system_prompt", Json.str s)]      else fields
     let fields := if let some b := a.budget       then fields ++ [("budget",        ToJson.toJson b)] else fields
     let fields := fields ++ [("memory", ToJson.toJson a.memory)]
+    let fields := if !a.extraPorts.isEmpty then fields ++ [("extra_ports", ToJson.toJson a.extraPorts)] else fields
     Json.mkObj fields
 
 instance : FromJson ActionConfig where
@@ -110,8 +113,9 @@ instance : FromJson ActionConfig where
           | _ => none
       | _ => none
     let memory := j.getObjValAs? MemoryMode "memory" |>.toOption |>.getD .both
+    let extraPorts := j.getObjValAs? (List Nat) "extra_ports" |>.toOption |>.getD []
     return { upstream, fork, mode, promptTemplate, series, backend, model, agent, systemPrompt,
-             budget, memory }
+             budget, memory, extraPorts }
 
 -- Listener config
 
@@ -241,6 +245,7 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
     series
     budget       := action.budget
     memory       := action.memory
+    extraPorts   := action.extraPorts
   }
 
 -- GitHub helpers

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -57,6 +57,8 @@ structure QueueEntry where
   budget        : Option Float  := none
   /-- Which memory directories to make available to the agent. Defaults to `both`. -/
   memory        : MemoryMode    := .both
+  /-- Extra TCP ports to allow in the sandbox, in addition to what the agent backend requires. -/
+  extraPorts    : List Nat      := []
 deriving Repr
 
 instance : ToJson QueueEntry where
@@ -80,6 +82,7 @@ instance : ToJson QueueEntry where
     let fields := if let some s := e.configPath    then fields ++ [("config_path",     Json.str s)]      else fields
     let fields := if let some b := e.budget        then fields ++ [("budget",          ToJson.toJson b)] else fields
     let fields := fields ++ [("memory", ToJson.toJson e.memory)]
+    let fields := if !e.extraPorts.isEmpty then fields ++ [("extra_ports", ToJson.toJson e.extraPorts)] else fields
     Json.mkObj fields
 
 instance : FromJson QueueEntry where
@@ -101,9 +104,10 @@ instance : FromJson QueueEntry where
     let configPath    := j.getObjValAs? String "config_path"    |>.toOption
     let budget        := j.getObjValAs? Float      "budget"  |>.toOption
     let memory        := j.getObjValAs? MemoryMode "memory"  |>.toOption |>.getD .both
+    let extraPorts    := j.getObjValAs? (List Nat) "extra_ports" |>.toOption |>.getD []
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, backend, model, continuesFrom, series, taskId, configPath,
-             budget, memory }
+             budget, memory, extraPorts }
 
 -- Directories and paths
 

--- a/Orchestra/Sandbox.lean
+++ b/Orchestra/Sandbox.lean
@@ -45,7 +45,8 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
     (systemPrompt : Option String := none)
     (resume : Option String := none)
     (budget : Float := 4.0)
-    (cancelToken : Option Std.CancellationToken := none) : IO LaunchResult := do
+    (cancelToken : Option Std.CancellationToken := none)
+    (extraPorts : List Nat := []) : IO LaunchResult := do
   -- Run agent-specific MCP setup (writes config files, returns extra env vars)
   let (mcpContext, agentEnv) ← agentDef.setupMcp serverPort model systemPrompt
   let paths := agentDef.sandboxPaths
@@ -81,9 +82,12 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
   for p in memoryDirs do
     if ← System.FilePath.pathExists p then
       args := args.push "--rw" |>.push p
-  -- Network: allow connecting to the local MCP server and external HTTPS
+  -- Network: allow connecting to the local MCP server, backend-required ports, and extra ports
   args := args.push "--connect-tcp" |>.push (toString serverPort)
-  args := args.push "--connect-tcp" |>.push "443"
+  for p in agentDef.ports do
+    args := args.push "--connect-tcp" |>.push (toString p)
+  for p in extraPorts do
+    args := args.push "--connect-tcp" |>.push (toString p)
   -- Environment variables for the sandboxed command
   args := args.push "--env" |>.push s!"GH_TOKEN={ghToken}"
   -- Pass through inherited env vars by name

--- a/OrchestraTest.lean
+++ b/OrchestraTest.lean
@@ -1,0 +1,97 @@
+import Lean.Data.Json
+import Orchestra.Config
+import Orchestra.Listener
+import Orchestra.Queue
+
+open Lean (Json FromJson ToJson)
+open Orchestra
+open Orchestra.Listener
+
+private def assertEq [BEq α] [Repr α] (desc : String) (expected actual : α) : IO Unit :=
+  if expected == actual then
+    IO.println s!"  PASS: {desc}"
+  else do
+    IO.eprintln s!"  FAIL: {desc}"
+    IO.eprintln s!"    expected: {repr expected}"
+    IO.eprintln s!"    actual:   {repr actual}"
+    throw (.userError s!"test failed: {desc}")
+
+private def testTaskExtraPorts : IO Unit := do
+  IO.println "Task.extraPorts"
+  let json ← IO.ofExcept <| Json.parse
+    r#"{"upstream":"u","fork":"f","mode":"fork","prompt":"p","extra_ports":[8080,9090]}"#
+  let task ← IO.ofExcept (FromJson.fromJson? json : Except String Task)
+  assertEq "extra_ports parsed correctly" [8080, 9090] task.extraPorts
+
+private def testTaskExtraPortsDefault : IO Unit := do
+  IO.println "Task.extraPorts default"
+  let json ← IO.ofExcept <| Json.parse
+    r#"{"upstream":"u","fork":"f","mode":"fork","prompt":"p"}"#
+  let task ← IO.ofExcept (FromJson.fromJson? json : Except String Task)
+  assertEq "extra_ports defaults to []" [] task.extraPorts
+
+private def testActionConfigExtraPorts : IO Unit := do
+  IO.println "ActionConfig.extraPorts"
+  let json ← IO.ofExcept <| Json.parse
+    r#"{"upstream":"u","fork":"f","mode":"fork","prompt_template":"tmpl","extra_ports":[443,8443]}"#
+  let cfg ← IO.ofExcept (FromJson.fromJson? json : Except String ActionConfig)
+  assertEq "extra_ports parsed correctly" [443, 8443] cfg.extraPorts
+
+private def testActionConfigExtraPortsDefault : IO Unit := do
+  IO.println "ActionConfig.extraPorts default"
+  let json ← IO.ofExcept <| Json.parse
+    r#"{"upstream":"u","fork":"f","mode":"fork","prompt_template":"tmpl"}"#
+  let cfg ← IO.ofExcept (FromJson.fromJson? json : Except String ActionConfig)
+  assertEq "extra_ports defaults to []" [] cfg.extraPorts
+
+private def testQueueEntryExtraPortsRoundTrip : IO Unit := do
+  IO.println "QueueEntry.extraPorts round-trip"
+  let entry : Queue.QueueEntry := {
+    id := "test-id"
+    createdAt := "2026-01-01T00:00:00Z"
+    upstream := "u"
+    fork := "f"
+    mode := .fork
+    prompt := "p"
+    extraPorts := [3000, 8080]
+  }
+  let json := ToJson.toJson entry
+  let entry' ← IO.ofExcept (FromJson.fromJson? json : Except String Queue.QueueEntry)
+  assertEq "extra_ports survives round-trip" [3000, 8080] entry'.extraPorts
+
+private def testQueueEntryExtraPortsEmpty : IO Unit := do
+  IO.println "QueueEntry.extraPorts empty round-trip"
+  let entry : Queue.QueueEntry := {
+    id := "test-id"
+    createdAt := "2026-01-01T00:00:00Z"
+    upstream := "u"
+    fork := "f"
+    mode := .fork
+    prompt := "p"
+  }
+  let json := ToJson.toJson entry
+  let entry' ← IO.ofExcept (FromJson.fromJson? json : Except String Queue.QueueEntry)
+  assertEq "empty extra_ports survives round-trip" [] entry'.extraPorts
+
+def main : IO UInt32 := do
+  let tests : List (IO Unit) := [
+    testTaskExtraPorts,
+    testTaskExtraPortsDefault,
+    testActionConfigExtraPorts,
+    testActionConfigExtraPortsDefault,
+    testQueueEntryExtraPortsRoundTrip,
+    testQueueEntryExtraPortsEmpty
+  ]
+  let mut failed := 0
+  for test in tests do
+    try
+      test
+    catch e =>
+      IO.eprintln s!"  Error: {e}"
+      failed := failed + 1
+  if failed == 0 then
+    IO.println s!"\nAll {tests.length} tests passed."
+    return 0
+  else
+    IO.eprintln s!"\n{failed}/{tests.length} tests FAILED."
+    return 1

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -17,3 +17,7 @@ root = "Main"
 [[lean_exe]]
 name = "orchestra-mcp-test"
 root = "McpTest"
+
+[[lean_exe]]
+name = "orchestra-test"
+root = "OrchestraTest"


### PR DESCRIPTION
Closes #43

## Summary

- Added `ports : List UInt16 := [443]` to `AgentDef`, replacing the hardcoded `443` in `Sandbox.lean` so each backend explicitly declares the ports it requires
- Added `extraPorts : List Nat := []` to `Task`, `ActionConfig`, and `QueueEntry`, configurable via `extra_ports` in JSON
- `Sandbox.launchAgent` now accepts an `extraPorts` parameter and appends `--connect-tcp` for each port in `agentDef.ports ++ extraPorts`
- Added a test executable (`OrchestraTest`) with 6 tests covering JSON parsing and round-trip serialization of `extra_ports`

## Usage

In a task JSON file:
```json
{
  "upstream": "owner/repo",
  "fork": "fork/repo",
  "mode": "pr",
  "prompt": "...",
  "extra_ports": [8080, 9090]
}
```

In a listener action config:
```json
{
  "action": {
    "upstream": "owner/repo",
    "fork": "fork/repo",
    "mode": "fork",
    "prompt_template": "...",
    "extra_ports": [3000]
  }
}
```

## Test plan

- [x] `lake build` compiles cleanly
- [x] `orchestra-test` passes all 6 tests (Task/ActionConfig/QueueEntry parsing and round-trips)
