### PR TITLE
Add priority to queue (issue #47)

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -143,6 +143,7 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
     continuesFrom, series
     backend := task.backend, model := task.model, agent := task.agent
     systemPrompt := task.systemPrompt, budget := task.budget
+    priority := task.priority
   }
   TaskStore.saveTask initialRecord
   -- Resolve initial resume session from the continued task
@@ -455,6 +456,7 @@ private def resumeHandler (p : Parsed) : IO UInt32 := do
     agent        := prevRecord.agent
     systemPrompt := prevRecord.systemPrompt
     budget       := budgetFlag.orElse (fun _ => prevRecord.budget)
+    priority     := prevRecord.priority
   }
   let _ ← runTask appConfig task 0 debug (continuesFrom := some prevId) (series := some seriesName)
   return (0 : UInt32)
@@ -476,6 +478,7 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
   let resumeSeries  := p.flag? "resume"    |>.map (·.as! String)
   let prompt        := p.flag? "prompt"    |>.map (·.as! String)
   let budgetFlag    := p.flag? "budget"    |>.bind (fun v => parseFloat? (v.as! String))
+  let priorityFlag  := p.flag? "priority"  |>.map (·.as! Nat)
   let taskFile?     := (p.variableArgsAs? String |>.getD #[])[0]?
   match resumeSeries, taskFile? with
   | some _, some _ =>
@@ -509,6 +512,7 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
       agent         := prevRecord.agent
       systemPrompt  := prevRecord.systemPrompt
       budget        := budgetFlag.orElse (fun _ => prevRecord.budget)
+      priority      := priorityFlag.getD prevRecord.priority
     }
     Queue.saveEntry entry
     IO.println entry.id
@@ -550,6 +554,7 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
         authSource   := task.authSource
         tools        := task.tools
         readOnly     := task.readOnly
+        priority     := priorityFlag.getD task.priority
       }
       Queue.saveEntry entry
       IO.println entry.id
@@ -674,6 +679,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         authSource   := entry.authSource
         tools        := entry.tools
         readOnly     := entry.readOnly
+        priority     := entry.priority
       }
       let cfg ← match entry.configPath with
         | none    => pure appConfig
@@ -747,13 +753,13 @@ private def queueListHandler (p : Parsed) : IO UInt32 := do
     IO.println "No queue entries found."
     return (0 : UInt32)
   IO.println ""
-  IO.println s!"{padRight "ID" 16} {padRight "CREATED" 20} {padRight "FORK" 28} {padRight "STATUS" 9} SERIES"
-  IO.println (String.ofList (List.replicate 85 '-'))
+  IO.println s!"{padRight "ID" 16} {padRight "CREATED" 20} {padRight "FORK" 28} {padRight "STATUS" 9} PRIORITY SERIES"
+  IO.println (String.ofList (List.replicate 93 '-'))
   for e in entries do
     let status := match e.status with
       | .pending => "pending" | .running => "running" | .done => "done" | .failed => "failed"
       | .unfinished => "unfinished" | .cancelled => "cancelled"
-    IO.println s!"{padRight e.id 16} {padRight e.createdAt 20} {padRight e.fork 28} {padRight status 10} {e.series.getD ""}"
+    IO.println s!"{padRight e.id 16} {padRight e.createdAt 20} {padRight e.fork 28} {padRight status 10} {padRight (toString e.priority) 8} {e.series.getD ""}"
   return (0 : UInt32)
 
 private def queueListenersHandler (p : Parsed) : IO UInt32 := do
@@ -791,14 +797,15 @@ private def queueStatusHandler (_ : Parsed) : IO UInt32 := do
   else
     IO.println s!"Queue: {active.size} task(s)"
     IO.println ""
-    IO.println s!"{padRight "ID" 16} {padRight "FORK" 32} {padRight "STATUS" 9} SERIES"
-    IO.println (String.ofList (List.replicate 70 '-'))
-    -- Show running first, then pending in oldest-first order
+    IO.println s!"{padRight "ID" 16} {padRight "FORK" 32} {padRight "STATUS" 9} PRIORITY SERIES"
+    IO.println (String.ofList (List.replicate 78 '-'))
+    -- Show running first, then pending ordered by priority desc, then oldest first
     let running := active.filter (fun e => e.status == .running)
-    let pending := (active.filter (fun e => e.status == .pending)).toList.reverse.toArray
-    for e in running ++ pending do
+    let pendingArr := active.filter (fun e => e.status == .pending)
+    let pendingByPriority := pendingArr.qsort (fun a b => a.priority > b.priority)
+    for e in running ++ pendingByPriority do
       let status := if e.status == .running then "running" else "pending"
-      IO.println s!"{padRight e.id 16} {padRight e.fork 32} {padRight status 9} {e.series.getD ""}"
+      IO.println s!"{padRight e.id 16} {padRight e.fork 32} {padRight status 9} {padRight (toString e.priority) 8} {e.series.getD ""}"
   -- Listener status
   let listenerConfigs ← Listener.loadAllListenerConfigs (← Listener.listenersDir)
   if !listenerConfigs.isEmpty then
@@ -939,6 +946,7 @@ private def queueAddCmd : Cmd := `[Cli|
     r, resume : String; "Continue the latest run in a named series (requires --prompt)"
     p, prompt : String; "Prompt for the new agent run (used with --resume)"
     budget : String; "Maximum spend in USD, overrides task file (default: 4.0)"
+    priority : Nat; "Priority for the queued entry (default: 10)"
 
   ARGS:
     ..."task-file" : String; "Path to the JSON task file (omit when using --resume)"
@@ -1007,6 +1015,7 @@ private def queueRetryHandler (p : Parsed) : IO UInt32 := do
       continuesFrom
       series       := entry.series
       configPath   := entry.configPath
+      priority     := entry.priority
     }
     Queue.saveEntry newEntry
     IO.println newEntry.id

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -140,6 +140,9 @@ structure Task where
   /-- If true, the project folder is mounted read-only in the sandbox.
       Useful for tasks that should only read the codebase (e.g. review tasks). -/
   readOnly : Bool := false
+  /-- Priority of this task. Natural number; higher = more important.
+      Defaults to 10 if not set. -/
+  priority : Nat := 10
 deriving Repr, Inhabited
 
 instance : FromJson Task where
@@ -157,8 +160,9 @@ instance : FromJson Task where
     let authSource := j.getObjValAs? String "auth_source" |>.toOption
     let tools := j.getObjValAs? (List String) "tools" |>.toOption
     let readOnly := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
+    let priority := j.getObjValAs? Nat "priority" |>.toOption |>.getD 10
     return { upstream, fork, mode, prompt, agent, systemPrompt, backend, model, budget, memory,
-             authSource, tools, readOnly }
+             authSource, tools, readOnly, priority }
 
 structure AppConfig where
   appId : Nat

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -134,6 +134,8 @@ structure ActionConfig where
   tools          : Option (List String) := none
   /-- If true, the project folder is mounted read-only in the sandbox. -/
   readOnly       : Bool := false
+  /-- Priority of the queue entry. Defaults to 10. -/
+  priority       : Nat  := 10
 
 instance : ToJson ActionConfig where
   toJson a :=
@@ -154,6 +156,7 @@ instance : ToJson ActionConfig where
     let fields := if let some s := a.authSource   then fields ++ [("auth_source",   Json.str s)]      else fields
     let fields := if let some t := a.tools        then fields ++ [("tools",         ToJson.toJson t)] else fields
     let fields := if a.readOnly                   then fields ++ [("read_only",      Json.bool true)]  else fields
+    let fields := if a.priority != 10          then fields ++ [("priority",       Json.num a.priority)] else fields
     Json.mkObj fields
 
 instance : FromJson ActionConfig where
@@ -180,8 +183,9 @@ instance : FromJson ActionConfig where
     let authSource := j.getObjValAs? String "auth_source" |>.toOption
     let tools := j.getObjValAs? (List String) "tools" |>.toOption
     let readOnly := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
+    let priority := j.getObjValAs? Nat "priority" |>.toOption |>.getD 10
     return { upstream, fork, mode, promptTemplate, series, backend, model, agent, systemPrompt,
-             budget, memory, authSource, tools, readOnly }
+             budget, memory, authSource, tools, readOnly, priority }
 
 -- Listener config
 
@@ -306,7 +310,7 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
   let fork :=
     let rendered := renderTemplate action.fork vars
     if rendered.isEmpty then lookupVar "fork" else rendered
-  IO.eprintln s!"[listener] buildQueueEntry: model={repr action.model} budget={repr action.budget} agent={repr action.agent}"
+  IO.eprintln s!"[listener] buildQueueEntry: model={repr action.model} budget={repr action.budget} agent={repr action.agent} priority={action.priority}"
   return {
     id, createdAt, status := .pending,
     upstream
@@ -323,6 +327,7 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
     authSource   := action.authSource
     tools        := action.tools
     readOnly     := action.readOnly
+    priority     := action.priority
   }
 
 -- GitHub helpers

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -64,6 +64,9 @@ structure QueueEntry where
   tools         : Option (List String) := none
   /-- If true, the project folder is mounted read-only in the sandbox. -/
   readOnly      : Bool := false
+  /-- Priority of this queue entry. Natural number; higher = more important.
+      Defaults to 10 if not set. -/
+  priority      : Nat := 10
 deriving Repr
 
 instance : ToJson QueueEntry where
@@ -90,6 +93,7 @@ instance : ToJson QueueEntry where
     let fields := if let some s := e.authSource    then fields ++ [("auth_source",     Json.str s)]      else fields
     let fields := if let some t := e.tools         then fields ++ [("tools",           ToJson.toJson t)] else fields
     let fields := if e.readOnly                    then fields ++ [("read_only",        Json.bool true)]  else fields
+    let fields := if e.priority != 10              then fields ++ [("priority",         Json.num e.priority)] else fields
     Json.mkObj fields
 
 instance : FromJson QueueEntry where
@@ -114,9 +118,10 @@ instance : FromJson QueueEntry where
     let authSource    := j.getObjValAs? String "auth_source" |>.toOption
     let tools         := j.getObjValAs? (List String) "tools" |>.toOption
     let readOnly      := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
+    let priority      := j.getObjValAs? Nat "priority" |>.toOption |>.getD 10
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, backend, model, continuesFrom, series, taskId, configPath,
-             budget, memory, authSource, tools, readOnly }
+             budget, memory, authSource, tools, readOnly, priority }
 
 -- Directories and paths
 
@@ -193,11 +198,18 @@ def loadAllEntries : IO (Array QueueEntry) := do
         result := result.push e
   return result.qsort (fun a b => a.id > b.id)
 
-/-- Return the oldest pending entry, or none.
-    loadAllEntries returns newest-first, so back? gives the oldest. -/
+/-- Return the next pending entry to run.
+    Entries are ordered by priority (higher first), with older entries breaking ties.
+    Returns none if no pending entries exist. -/
 def nextPending : IO (Option QueueEntry) := do
   let all ← loadAllEntries
-  return (all.filter (fun e => e.status == .pending)).back?
+  let pending := all.filter (fun e => e.status == .pending)
+  if pending.isEmpty then return none
+  -- Find the maximum priority
+  let maxPri := pending.foldl (·.max ·.priority) 0
+  -- Among entries with max priority, pick the oldest (last in newest-first array)
+  let maxPriEntries := pending.filter (·.priority == maxPri)
+  return (maxPriEntries.back? |>.filter (·.priority == maxPri))
 
 -- PID file management
 

--- a/Orchestra/TaskStore.lean
+++ b/Orchestra/TaskStore.lean
@@ -56,6 +56,8 @@ structure TaskRecord where
   systemPrompt  : Option String := none
   /-- Maximum spend in USD used for this run. -/
   budget        : Option Float  := none
+  /-- Priority used for queue ordering. Defaults to 10. -/
+  priority      : Nat           := 10
 deriving Repr
 
 instance : ToJson TaskRecord where
@@ -78,6 +80,7 @@ instance : ToJson TaskRecord where
     let fields := if let some s := r.agent         then fields ++ [("agent",          Json.str s)]     else fields
     let fields := if let some s := r.systemPrompt  then fields ++ [("system_prompt",  Json.str s)]     else fields
     let fields := if let some b := r.budget        then fields ++ [("budget",         ToJson.toJson b)] else fields
+    let fields := if r.priority != 10           then fields ++ [("priority",         Json.num r.priority)] else fields
     Json.mkObj fields
 
 instance : FromJson TaskRecord where
@@ -97,8 +100,9 @@ instance : FromJson TaskRecord where
     let agent         := j.getObjValAs? String "agent"          |>.toOption
     let systemPrompt  := j.getObjValAs? String "system_prompt"  |>.toOption
     let budget        := j.getObjValAs? Float  "budget"         |>.toOption
+    let priority      := j.getObjValAs? Nat   "priority"      |>.toOption |>.getD 10
     return { id, createdAt, upstream, fork, mode, prompt, status, sessionId,
-             continuesFrom, series, backend, model, agent, systemPrompt, budget }
+             continuesFrom, series, backend, model, agent, systemPrompt, budget, priority }
 
 -- Directories
 


### PR DESCRIPTION
Priority is a natural number with default 10. Higher priority tasks are dequeued first. When multiple pending entries share the same priority, older entries are processed first (FIFO within priority levels).

- Added `priority : Nat := 10` to `QueueEntry`, `Task`, `TaskRecord`, and `ActionConfig` (listener action).
- Updated `nextPending` to select by highest priority, oldest first for ties.
- Priority is optional everywhere - defaults to 10 if omitted.
- Tasks already running are never interrupted (existing behavior preserved).
- Added `--priority` CLI flag to `queue add`.
- Added priority column to `queue` and `queue status` output.
- Priority is propagated through all enqueue points (task file, series continuation, retry, listener build, resume).