### PR TITLE
Pass validation script output to retry prompt via {{validation_output}}

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -91,10 +91,13 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
   let mut sessionId : Option String := none
   let mut usageLimitHit := false
   let mut wasCancelled := false
+  let mut lastValidationOutput : String := ""
   let maxAttempts := repoConfig.validation.maxRetries + 1
   for attempt in List.range maxAttempts do
     RepoConfig.runHook repoPath "before.sh"
-    let prompt := if attempt == 0 then task.prompt else repoConfig.validation.retryPrompt
+    let prompt :=
+      if attempt == 0 then task.prompt
+      else repoConfig.validation.retryPrompt.replace "{{validation_output}}" lastValidationOutput
     let resume := if attempt == 0 then initialResume else sessionId
     IO.println s!"  Launching agent (attempt {attempt + 1}/{maxAttempts})..."
     let agentDef := match task.backend with
@@ -114,7 +117,10 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
       IO.println "  Agent hit usage limit."
       usageLimitHit := true
       break
-    let valid ← RepoConfig.runValidation repoPath
+    let (valid, validationOutput) ← RepoConfig.runValidation repoPath
+    lastValidationOutput := validationOutput
+    if !validationOutput.isEmpty then
+      IO.println s!"  Validation output:\n{validationOutput}"
     if valid then break
     if attempt + 1 < maxAttempts then
       IO.println s!"  Validation failed, retrying ({attempt + 1}/{repoConfig.validation.maxRetries})..."

--- a/Main.lean
+++ b/Main.lean
@@ -255,11 +255,18 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
       IO.println "  Agent hit usage limit."
       usageLimitHit := true
       break
+    let validationScript := repoPath / ".agent" / "validation.sh"
+    if !(← validationScript.pathExists) then
+      IO.println "  No validation script found, skipping validation."
+      break
+    IO.println "  Running validation script..."
     let (valid, validationOutput) ← RepoConfig.runValidation repoPath
     lastValidationOutput := validationOutput
     if !validationOutput.isEmpty then
       IO.println s!"  Validation output:\n{validationOutput}"
-    if valid then break
+    if valid then
+      IO.println "  Validation passed."
+      break
     if attempt + 1 < maxAttempts then
       IO.println s!"  Validation failed, retrying ({attempt + 1}/{repoConfig.validation.maxRetries})..."
     else

--- a/Main.lean
+++ b/Main.lean
@@ -255,8 +255,7 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
       IO.println "  Agent hit usage limit."
       usageLimitHit := true
       break
-    let validationScript := repoPath / ".agent" / "validation.sh"
-    if !(← validationScript.pathExists) then
+    if !(← RepoConfig.hasValidationScript repoPath) then
       IO.println "  No validation script found, skipping validation."
       break
     IO.println "  Running validation script..."

--- a/Orchestra/RepoConfig.lean
+++ b/Orchestra/RepoConfig.lean
@@ -75,20 +75,24 @@ def runInitIfNeeded (repoPath : System.FilePath) : IO Unit := do
 
 /--
 Run `.agent/validation.sh`.
-Returns `true` if the script passes (exit 0) or does not exist.
-Returns `false` if the script exits non-zero. Does not throw.
+Returns `(true, "")` if the script passes (exit 0) or does not exist.
+Returns `(false, output)` if the script exits non-zero, where `output` is the
+combined stdout and stderr of the script. Does not throw.
 -/
-def runValidation (repoPath : System.FilePath) : IO Bool := do
+def runValidation (repoPath : System.FilePath) : IO (Bool × String) := do
   let hookPath := agentDir repoPath / "validation.sh"
-  if !(← hookPath.pathExists) then return true
+  if !(← hookPath.pathExists) then return (true, "")
   let child ← IO.Process.spawn {
     cmd  := "bash"
     args := #[hookPath.toString]
     cwd  := repoPath
-    stdout := .inherit
-    stderr := .inherit
+    stdout := .piped
+    stderr := .piped
   }
+  let stdout ← child.stdout.readToEnd
+  let stderr ← child.stderr.readToEnd
   let code ← child.wait
-  return code == 0
+  let combined := (stdout ++ stderr).trimAscii.toString
+  return (code == 0, combined)
 
 end Orchestra.RepoConfig

--- a/Orchestra/RepoConfig.lean
+++ b/Orchestra/RepoConfig.lean
@@ -73,6 +73,10 @@ def runInitIfNeeded (repoPath : System.FilePath) : IO Unit := do
   runHook repoPath "init.sh"
   IO.FS.writeFile markerPath ""
 
+/-- Returns `true` if `.agent/validation.sh` exists in the repository. -/
+def hasValidationScript (repoPath : System.FilePath) : IO Bool :=
+  (agentDir repoPath / "validation.sh").pathExists
+
 /--
 Run `.agent/validation.sh`.
 Returns `(true, "")` if the script passes (exit 0) or does not exist.
@@ -80,8 +84,8 @@ Returns `(false, output)` if the script exits non-zero, where `output` is the
 combined stdout and stderr of the script. Does not throw.
 -/
 def runValidation (repoPath : System.FilePath) : IO (Bool × String) := do
+  if !(← hasValidationScript repoPath) then return (true, "")
   let hookPath := agentDir repoPath / "validation.sh"
-  if !(← hookPath.pathExists) then return (true, "")
   let child ← IO.Process.spawn {
     cmd  := "bash"
     args := #[hookPath.toString]


### PR DESCRIPTION
- Changes `runValidation` in `RepoConfig.lean` to return `(Bool × String)` — the exit status and the combined stdout+stderr of the validation script — instead of just `Bool`.
- Prints the validation output to the console after each failed validation run.
- Stores the captured output between loop iterations so the retry prompt can reference it via the `{{validation_output}}` template placeholder.

Usage example: In `.agent/config.json`, set a retry prompt that uses the placeholder:

```json
{
  "validation": {
    "retry_prompt": "Validation failed. Here is the output:\n\n{{validation_output}}\n\nPlease fix the issues above.",
    "max_retries": 3
  }
}
```

If the retry prompt does not contain `{{validation_output}}`, it behaves exactly as before (no substitution occurs).

Closes #49