### PR TITLE
Implement deterministic test agent

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -221,6 +221,7 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
     let agentDef := match task.backend with
       | some "pi"   => AgentDef.pi
       | some "vibe" => AgentDef.vibe
+      | some "test"  => AgentDef.testAgent
       | _           => AgentDef.claude
     let backendName := task.backend.getD "claude"
     let apiKeyEnv ← resolveAuthEnv appConfig agentDef backendName task.authSource

--- a/Orchestra.lean
+++ b/Orchestra.lean
@@ -2,6 +2,7 @@ import Orchestra.AgentDef
 import Orchestra.Agents.Claude
 import Orchestra.Agents.Pi
 import Orchestra.Agents.Vibe
+import Orchestra.Agents.Test
 import Orchestra.Config
 import Orchestra.GitHub
 import Orchestra.Listener

--- a/Orchestra/Agents/Test.lean
+++ b/Orchestra/Agents/Test.lean
@@ -1,0 +1,40 @@
+import Orchestra.AgentDef
+import Orchestra.StreamFormat
+import Lean.Data.Json
+
+open Lean (Json)
+
+namespace Orchestra.AgentDef
+
+/-- A deterministic test agent for verifying sandbox and MCP setup. -/
+def testAgent : AgentDef where
+  command := "python3"
+  sandboxPaths := {
+    rox     := ["/usr", "/lib", "/lib64", "/bin", "/sbin", "/nix"]
+    ro      := ["/etc", "/run", "/dev", "/proc", "/sys"]
+    rw      := ["/tmp"]
+    homeRox := [".elan", ".cache", ".local"]
+    homeRw  := [".test"]
+  }
+  setupMcp port _ _ := do
+    -- Configure a dummy MCP server using nc
+    let mcpConfig := Json.mkObj [("mcpServers", Json.mkObj [
+      ("agent", Json.mkObj [
+        ("command", .str "nc"),
+        ("args", .arr #[.str "127.0.0.1", .str (toString port)])
+      ])
+    ])]
+    let ts ← IO.monoNanosNow
+    let path := s!"/tmp/test-agent-mcp-{ts}.json"
+    IO.FS.writeFile (System.FilePath.mk path) mcpConfig.compress
+    return (path, #[])
+  buildArgs mcpConfigPath pluginDirs subAgent model systemPrompt resume budget prompt := Id.run do
+    -- Run the test agent script
+    return #["/home/agent/.agent/repos/chrisflav-agents/orchestra/Orchestra/Agents/TestAgent.py"]
+  parseOutputLine := StreamFormat.parseEvent
+  extractSessionId _ := pure none
+  cleanup path := try IO.FS.removeFile (System.FilePath.mk path) catch _ => pure ()
+  isUsageLimitError := stdUsageLimitError
+  envVarsOfAuthSource _ := #[]
+
+end Orchestra.AgentDef

--- a/Orchestra/Agents/TestAgent.py
+++ b/Orchestra/Agents/TestAgent.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import json
+import sys
+import os
+import socket
+
+def print_event(event_type, **kwargs):
+    event = {"type": event_type}
+    event.update(kwargs)
+    print(json.dumps(event), flush=True)
+
+def check_path(path, expected):
+    readable = os.access(path, os.R_OK)
+    writable = os.access(path, os.W_OK)
+    executable = os.access(path, os.X_OK)
+    
+    res = f"Path {path}: R={readable}, W={writable}, X={executable} (expected {expected})"
+    
+    passed = False
+    if expected == "ro":
+        passed = readable and not writable
+    elif expected == "rw":
+        passed = readable and writable
+    elif expected == "rox":
+        passed = readable and executable
+    elif expected == "none":
+        passed = not readable and not writable
+        
+    return res, passed
+
+def main():
+    # 1. Init event
+    print_event("system", subtype="init", session_id="test-session", model="test-agent")
+
+    # 2. Check MCP server
+    # The port is passed as an environment variable by the runner (we'll configure this in AgentDef)
+    mcp_port = os.environ.get("ORCHESTRA_MCP_PORT")
+    if mcp_port:
+        try:
+            # Try to connect to the MCP server
+            with socket.create_connection(("127.0.0.1", int(mcp_port)), timeout=1):
+                print_event("assistant", item={"type": "text", "text": "MCP server is available"})
+        except Exception as e:
+            print_event("assistant", item={"type": "text", "text": f"MCP server is NOT available: {e}"})
+    else:
+        print_event("assistant", item={"type": "text", "text": "MCP port not provided in environment"})
+
+    # 3. Check paths
+    # We check a set of paths that should be configured in the AgentDef
+    paths_to_check = {
+        "/usr": "rox",
+        "/etc": "ro",
+        "/tmp": "rw",
+        "/root": "none",
+    }
+    
+    all_passed = True
+    for path, expected in paths_to_check.items():
+        msg, passed = check_path(path, expected)
+        print_event("assistant", item={"type": "text", "text": msg})
+        if not passed:
+            all_passed = False
+
+    # 4. Final result
+    if all_passed:
+        print_event("result", subtype="success", result="All deterministic tests passed")
+    else:
+        print_event("result", subtype="error", result="Some deterministic tests failed")
+
+if __name__ == "__main__":
+    main()

--- a/Orchestra/Sandbox.lean
+++ b/Orchestra/Sandbox.lean
@@ -103,6 +103,7 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
     args := args.push "--connect-tcp" |>.push (toString p)
   -- Environment variables for the sandboxed command
   args := args.push "--env" |>.push s!"GH_TOKEN={ghToken}"
+  args := args.push "--env" |>.push s!"ORCHESTRA_MCP_PORT={serverPort}"
   args := args.push "--env" |>.push "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"
   -- Pass through inherited env vars by name
   for name in ["SHELL", "PATH", "HOME", "USER", "TERM"] do

--- a/Test.lean
+++ b/Test.lean
@@ -1,3 +1,4 @@
 import Test.TestM
 import Test.ListenerConfigTest
 import Test.StreamFormatTest
+import Test.AgentLaunchTest

--- a/Test/AgentLaunchTest.lean
+++ b/Test/AgentLaunchTest.lean
@@ -1,0 +1,21 @@
+import Test.TestM
+import Orchestra
+import Orchestra.Sandbox
+
+open Orchestra
+
+@[test]
+def agentLaunchTest : Test := do
+  let repoPath := System.FilePath.mk "."
+  let prompt := "Hello, agent!"
+  let serverPort := 8080
+  let ghToken := "dummy-token"
+  
+  let result ← Sandbox.launchAgent 
+    AgentDef.testAgent 
+    repoPath 
+    prompt 
+    serverPort 
+    ghToken
+
+  TestM.assert (result.exitCode == 0) (msg := "agent should exit with code 0")


### PR DESCRIPTION
## Summary
Implemented a deterministic test agent to increase the test surface.

- Added `TestAgent.py` to perform checks on MCP server availability and filesystem permissions.
- Defined `testAgent` in `Orchestra.Agents.Test` and integrated it into the `orchestra` CLI.
- Updated `Orchestra.Sandbox` to pass the MCP server port as an environment variable (`ORCHESTRA_MCP_PORT`), allowing the test agent to verify connectivity.
- Verified that the project builds successfully with the new changes.