### PR TITLE
Allow customising the prepend prompt by specifying a different name

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -200,7 +200,7 @@ private def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : B
     | none,    some mp => some mp
     | some sp, some mp => some (sp ++ "\n\n" ++ mp)
   -- 5b. Load prepend prompt and apply to task prompt
-  let prependPrompt ← loadPrependPrompt
+  let prependPrompt ← loadPrependPrompt task.prependPrompt
   let baseTaskPrompt :=
     match prependPrompt with
     | none    => task.prompt
@@ -467,6 +467,7 @@ private def resumeHandler (p : Parsed) : IO UInt32 := do
     model        := prevRecord.model
     agent        := prevRecord.agent
     systemPrompt := prevRecord.systemPrompt
+    prependPrompt := prevRecord.prependPrompt
     budget       := budgetFlag.orElse (fun _ => prevRecord.budget)
     priority     := prevRecord.priority
   }
@@ -523,6 +524,7 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
       model         := prevRecord.model
       agent         := prevRecord.agent
       systemPrompt  := prevRecord.systemPrompt
+      prependPrompt := prevRecord.prependPrompt
       budget        := budgetFlag.orElse (fun _ => prevRecord.budget)
       priority      := priorityFlag.getD prevRecord.priority
     }
@@ -558,6 +560,7 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
         prompt       := task.prompt
         agent        := task.agent
         systemPrompt := task.systemPrompt
+        prependPrompt := task.prependPrompt
         backend      := task.backend
         model        := task.model
         continuesFrom, series
@@ -684,6 +687,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         prompt       := entry.prompt
         agent        := entry.agent
         systemPrompt := entry.systemPrompt
+        prependPrompt := entry.prependPrompt
         backend      := entry.backend
         model        := entry.model
         budget       := entry.budget

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -122,6 +122,7 @@ structure Task where
   prompt : String
   agent : Option String := none
   systemPrompt : Option String := none
+  prependPrompt : Option String := none
   /-- Agent backend to use: "claude" (default) or "vibe". -/
   backend : Option String := none
   /-- Model override passed to the agent (e.g. "sonnet", "devstral-small"). -/
@@ -153,6 +154,7 @@ instance : FromJson Task where
     let prompt ← j.getObjValAs? String "prompt"
     let agent := j.getObjValAs? String "agent" |>.toOption
     let systemPrompt := j.getObjValAs? String "system_prompt" |>.toOption
+    let prependPrompt := j.getObjValAs? String "prepend_prompt" |>.toOption
     let backend := j.getObjValAs? String "backend" |>.toOption
     let model := j.getObjValAs? String "model" |>.toOption
     let budget := j.getObjValAs? Float "budget" |>.toOption
@@ -161,7 +163,7 @@ instance : FromJson Task where
     let tools := j.getObjValAs? (List String) "tools" |>.toOption
     let readOnly := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
     let priority := j.getObjValAs? Nat "priority" |>.toOption |>.getD 10
-    return { upstream, fork, mode, prompt, agent, systemPrompt, backend, model, budget, memory,
+    return { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model, budget, memory,
              authSource, tools, readOnly, priority }
 
 structure AppConfig where
@@ -253,12 +255,12 @@ def loadSystemPrompt (name : Option String := none) : IO (Option String) := do
     return none
 
 /--
-Load a prepend prompt from `~/.agent/prompts/default-prepend.md`.
-If the file exists, its contents will be prepended to every task prompt.
-Returns `none` if the file does not exist.
+Load a prepend prompt from `~/.agent/prompts/<name>.md`.
+If `name` is `none`, reads `default-prepend.md`. Returns `none` if the file does not exist.
 -/
-def loadPrependPrompt : IO (Option String) := do
-  let promptPath ← expandHome "~/.agent/prompts/default-prepend.md"
+def loadPrependPrompt (name : Option String := none) : IO (Option String) := do
+  let promptName := name.getD "default-prepend"
+  let promptPath ← expandHome s!"~/.agent/prompts/{promptName}.md"
   if ← promptPath.pathExists then
     return some (← IO.FS.readFile promptPath)
   else

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -47,6 +47,7 @@ structure QueueEntry where
   prompt        : String
   agent         : Option String := none
   systemPrompt  : Option String := none
+  prependPrompt : Option String := none
   backend       : Option String := none
   model         : Option String := none
   continuesFrom : Option String := none
@@ -82,6 +83,7 @@ instance : ToJson QueueEntry where
     ]
     let fields := if let some s := e.agent         then fields ++ [("agent",           Json.str s)]      else fields
     let fields := if let some s := e.systemPrompt  then fields ++ [("system_prompt",   Json.str s)]      else fields
+    let fields := if let some s := e.prependPrompt   then fields ++ [("prepend_prompt",   Json.str s)]      else fields
     let fields := if let some s := e.backend       then fields ++ [("backend",         Json.str s)]      else fields
     let fields := if let some s := e.model         then fields ++ [("model",           Json.str s)]      else fields
     let fields := if let some s := e.continuesFrom then fields ++ [("continues_from",  Json.str s)]      else fields
@@ -107,6 +109,7 @@ instance : FromJson QueueEntry where
     let prompt       ← j.getObjValAs? String "prompt"
     let agent         := j.getObjValAs? String "agent"          |>.toOption
     let systemPrompt  := j.getObjValAs? String "system_prompt"  |>.toOption
+    let prependPrompt   := j.getObjValAs? String "prepend_prompt"  |>.toOption
     let backend       := j.getObjValAs? String "backend"        |>.toOption
     let model         := j.getObjValAs? String "model"          |>.toOption
     let continuesFrom := j.getObjValAs? String "continues_from" |>.toOption
@@ -120,7 +123,7 @@ instance : FromJson QueueEntry where
     let readOnly      := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
     let priority      := j.getObjValAs? Nat "priority" |>.toOption |>.getD 10
     return { id, createdAt, status, upstream, fork, mode, prompt,
-             agent, systemPrompt, backend, model, continuesFrom, series, taskId, configPath,
+             agent, systemPrompt, prependPrompt, backend, model, continuesFrom, series, taskId, configPath,
              budget, memory, authSource, tools, readOnly, priority }
 
 -- Directories and paths

--- a/Orchestra/TaskStore.lean
+++ b/Orchestra/TaskStore.lean
@@ -54,6 +54,8 @@ structure TaskRecord where
   agent         : Option String := none
   /-- System prompt file name used for this run. Inherited by continuations. -/
   systemPrompt  : Option String := none
+  /-- Prepend prompt file name used for this run. Inherited by continuations. -/
+  prependPrompt : Option String := none
   /-- Maximum spend in USD used for this run. -/
   budget        : Option Float  := none
   /-- Priority used for queue ordering. Defaults to 10. -/
@@ -79,6 +81,7 @@ instance : ToJson TaskRecord where
     let fields := if let some s := r.model         then fields ++ [("model",          Json.str s)]     else fields
     let fields := if let some s := r.agent         then fields ++ [("agent",          Json.str s)]     else fields
     let fields := if let some s := r.systemPrompt  then fields ++ [("system_prompt",  Json.str s)]     else fields
+    let fields := if let some s := r.prependPrompt   then fields ++ [("prepend_prompt",  Json.str s)]     else fields
     let fields := if let some b := r.budget        then fields ++ [("budget",         ToJson.toJson b)] else fields
     let fields := if r.priority != 10           then fields ++ [("priority",         Json.num r.priority)] else fields
     Json.mkObj fields
@@ -99,10 +102,11 @@ instance : FromJson TaskRecord where
     let model         := j.getObjValAs? String "model"          |>.toOption
     let agent         := j.getObjValAs? String "agent"          |>.toOption
     let systemPrompt  := j.getObjValAs? String "system_prompt"  |>.toOption
+    let prependPrompt   := j.getObjValAs? String "prepend_prompt"  |>.toOption
     let budget        := j.getObjValAs? Float  "budget"         |>.toOption
     let priority      := j.getObjValAs? Nat   "priority"      |>.toOption |>.getD 10
     return { id, createdAt, upstream, fork, mode, prompt, status, sessionId,
-             continuesFrom, series, backend, model, agent, systemPrompt, budget, priority }
+             continuesFrom, series, backend, model, agent, systemPrompt, prependPrompt, budget, priority }
 
 -- Directories
 


### PR DESCRIPTION
Allow customizing the prepend prompt by specifying a different name in the task definition.