### PR TITLE
Fix .agent setup (#62)

### DIFF
--- a/.agent/validation.sh
+++ b/.agent/validation.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "==> Building..."
 lake build
 
-echo "==> Running listener-config-test..."
-.lake/build/bin/listener-config-test
+echo "==> Running tests..."
+lake test
 
 echo "==> All checks passed."

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tasks.json
 container/*.squashfs
 container/*.tar.xz
+.agent/.initialized


### PR DESCRIPTION
This PR fixes the `.agent` setup as requested in issue #62:
- Adds `.agent/.initialized` to `.gitignore`
- Renames `.agent/validate.sh` to `.agent/validation.sh`
- Replaces manual test step in `.agent/validation.sh` with `lake test`