### PR TITLE
Track usage limits per auth source and delay tasks instead of cancelling

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -524,6 +524,8 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
   Queue.markStaleRunningAsUnfinished
   Queue.cancelStaleConcertEntries
   Queue.cancelStaleRunningConcerts
+  -- Remove expired usage limit blocks so work can resume after a reset
+  UsageLimits.clearExpiredBlocksOnStartup
   let appConfig ← loadAppConfig (configPath.map System.FilePath.mk)
   -- Shared concurrency primitives
   let shutdownToken  ← Std.CancellationToken.new
@@ -549,9 +551,12 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
     catch _ => pure ()
   -- Helper: atomically claim the next pending entry, marking it as running.
   -- Serialised by claimMutex so that multiple workers cannot claim the same entry.
+  -- Skips entries whose (backend, authSource) is currently usage-limit-blocked.
   let claimNextEntry : IO (Option Queue.QueueEntry) := do
     claimMutex.lock
-    let entry ← Queue.nextPending
+    UsageLimits.clearExpiredBlocks
+    let blocked ← UsageLimits.blockedSources
+    let entry ← Queue.nextPending blocked
     if let some e := entry then
       Queue.saveEntry { e with status := .running }
     claimMutex.unlock
@@ -588,6 +593,34 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
     let cfg ← match entry.configPath with
       | none    => pure appConfig
       | some cp => loadAppConfig (some (System.FilePath.mk cp))
+    let backend := entry.backend.getD "claude"
+    let agentDef := match entry.backend with
+      | some "pi"       => AgentDef.pi
+      | some "vibe"     => AgentDef.vibe
+      | some "opencode" => AgentDef.opencode
+      | _               => AgentDef.claude
+    -- Resolve the auth source for this entry so we can query and block per source.
+    let authSrc : Option AuthSource := do
+      let ac ← cfg.agentAuthConfigs.find? (fun c => c.name == backend)
+      match entry.authSource with
+      | some label => ac.authSources.find? (fun s => s.label == label)
+      | none =>
+        match ac.defaultAuthSource with
+        | some defLabel => ac.authSources.find? (fun s => s.label == defLabel)
+        | none => if ac.authSources.size == 1 then ac.authSources[0]? else none
+    -- Proactively query all current usage limits before starting the task.
+    -- This catches session, weekly all-models, and weekly per-model limits.
+    if let some src := authSrc then
+      match ← try agentDef.checkCurrentUsageLimits src catch _ => pure none with
+      | some resetAt =>
+        removeToken
+        Queue.saveEntry { entry with status := .unfinished }
+        UsageLimits.blockSource backend entry.authSource (some resetAt)
+        Queue.cancelDependents entry.id
+        IO.println s!"  Pre-task limit check: {backend}{match entry.authSource with | some s => s!" ({s})" | none => ""} is over quota. Task delayed (resets at {resetAt})."
+        ConcertManager.signal concertMgr (entry.concertStepKey.getD "") none
+        return
+      | none => pure ()
     try
       let (taskId, usageLimitHit, outputJson) ← TaskRunner.runTask cfg task 0 debug
         (continuesFrom := entry.continuesFrom) (series := entry.series)
@@ -603,9 +636,16 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         ConcertManager.signal concertMgr (entry.concertStepKey.getD "") outputJson
       else if usageLimitHit then
         Queue.saveEntry { entry with status := .unfinished, taskId := some taskId }
-        Queue.cancelPendingByBackend entry.backend entry.id
+        -- Try to get an accurate reset time from the provider API.
+        let resetAt ← match authSrc with
+          | none    => pure none
+          | some s  => try agentDef.queryUsageReset s catch _ => pure none
+        UsageLimits.blockSource backend entry.authSource resetAt
         Queue.cancelDependents taskId
-        IO.println s!"  Cancelled pending {entry.backend.getD "claude"} tasks and dependents."
+        let resetMsg ← match ← UsageLimits.resetTimeFor backend entry.authSource with
+          | some t => pure s!" (resets at {t})"
+          | none   => pure ""
+        IO.println s!"  Usage limit hit for {backend}{match entry.authSource with | some s => s!" ({s})" | none => ""}. Pending tasks delayed{resetMsg}."
         ConcertManager.signal concertMgr (entry.concertStepKey.getD "") none
       else
         Queue.saveEntry { entry with status := .done, taskId := some taskId, outputJson }

--- a/Orchestra.lean
+++ b/Orchestra.lean
@@ -18,5 +18,6 @@ import Orchestra.Server
 import Orchestra.StreamFormat
 import Orchestra.TaskRunner
 import Orchestra.TaskStore
+import Orchestra.UsageLimits
 import Orchestra.Workflow
 import Orchestra.WorkflowParser

--- a/Orchestra/AgentDef.lean
+++ b/Orchestra/AgentDef.lean
@@ -40,6 +40,16 @@ structure AgentDef where
       Called to determine which environment variables to inject when a specific auth source is selected.
       Authentication kinds not supported by the backend produce an empty array. -/
   envVarsOfAuthSource : AuthSource → Array (String × String)
+  /-- Query the provider API to find when the usage limit for the given auth source will reset.
+      Returns an ISO 8601 UTC timestamp string if the limit is currently active and the backend
+      supports this query. Returns `none` if the backend does not support proactive limit checking
+      or if no limit is currently active. -/
+  queryUsageReset : AuthSource → IO (Option String) := fun _ => pure none
+  /-- Proactively query all current usage limits for the given auth source before starting a task.
+      Checks every limit type the backend exposes (e.g. per-session, weekly all-models,
+      weekly per-model).  Returns `some resetTime` (ISO 8601 UTC) if *any* limit is currently
+      exhausted, `none` when there is sufficient headroom. -/
+  checkCurrentUsageLimits : AuthSource → IO (Option String) := fun _ => pure none
 
 namespace AgentDef
 

--- a/Orchestra/Agents/Claude.lean
+++ b/Orchestra/Agents/Claude.lean
@@ -10,8 +10,11 @@ namespace Orchestra.AgentDef
 /-- Run curl with the given args; return (stdout, exit code). -/
 private def runCurl (args : Array String) : IO (String × UInt32) := do
   let child ← IO.Process.spawn {
-    cmd := "curl"; args
-    stdout := .piped; stderr := .null; stdin := .null
+    cmd  := "curl"
+    args := args
+    stdout := .piped
+    stderr := .null
+    stdin  := .null
   }
   let out ← child.stdout.readToEnd
   let code ← child.wait
@@ -30,35 +33,35 @@ private def findHeader (output : String) (name : String) : Option String :=
     (e.g. weekly Sonnet / weekly all-models limits). -/
 private def exhaustedResetTime (headers : String) : Option String :=
   let buckets := [
-    -- Per-minute / per-day limits
     "requests", "tokens", "input-tokens", "output-tokens"
   ]
-  -- Collect the reset times of all exhausted buckets.
-  let resetTimes := buckets.filterMap fun bucket =>
+  -- Collect the reset times of all exhausted standard buckets.
+  let standardResets := buckets.filterMap fun bucket =>
     let remKey := s!"anthropic-ratelimit-{bucket}-remaining"
     let rstKey := s!"anthropic-ratelimit-{bucket}-reset"
     match findHeader headers remKey with
     | none => none
     | some rem =>
-      if rem.trim == "0" then findHeader headers rstKey
+      if rem.trimAscii.toString == "0" then findHeader headers rstKey
       else none
-  -- Also capture any model-specific limit headers (e.g. weekly Sonnet-only, weekly all-models).
+  -- Also capture any model-specific limit headers (weekly Sonnet-only, weekly all-models).
   -- These follow the pattern: anthropic-ratelimit-<model-slug>-tokens-remaining
   let modelSpecific := headers.splitOn "\n" |>.filterMap fun line =>
     let lower := line.toLower
     if lower.startsWith "anthropic-ratelimit-" && lower.contains "-remaining:" then
-      let parts := lower.splitOn "-remaining:"
-      let remStr := parts.getD 1 "" |>.trim
+      let remStr := (lower.splitOn "-remaining:" |>.getD 1 "").trimAscii.toString
       if remStr == "0" then
-        -- Derive the reset key by replacing -remaining: with -reset:
         let resetLine := line.replace "-remaining:" "-reset:"
-        let resetVal := resetLine.splitOn "-reset:" |>.getD 1 "" |>.trim
+        let resetVal := (resetLine.splitOn "-reset:" |>.getD 1 "").trimAscii.toString
         if resetVal.isEmpty then none else some resetVal
       else none
     else none
-  let allResets := resetTimes ++ modelSpecific
+  let allResets := standardResets ++ modelSpecific
   -- Return the earliest reset time (lexicographic ISO 8601 comparison is correct).
-  allResets.foldl (fun acc t => match acc with | none => some t | some a => some (min a t)) none
+  allResets.foldl (fun acc t =>
+    match acc with
+    | none   => some t
+    | some a => some (if a ≤ t then a else t)) none
 
 /-- Proactively query the Anthropic API to check whether any usage limit is currently
     exhausted.  Makes a minimal probe request (1 output token) and inspects the
@@ -91,9 +94,8 @@ private def queryClaudeUsageLimits (src : AuthSource) : IO (Option String) := do
   | "429" =>
     -- Currently rate-limited: pick the earliest reset from the response headers.
     let resetTime :=
-      exhaustedResetTime output
-        |>.orElse (findHeader output "retry-after")
-        |>.orElse (findHeader output "x-ratelimit-reset")
+      (exhaustedResetTime output).orElse (fun _ => findHeader output "retry-after")
+        |>.orElse (fun _ => findHeader output "x-ratelimit-reset")
     match resetTime with
     | some t => return some t
     | none   => return some (← UsageLimits.estimateResetTime)

--- a/Orchestra/Agents/Claude.lean
+++ b/Orchestra/Agents/Claude.lean
@@ -1,10 +1,108 @@
 import Orchestra.AgentDef
 import Orchestra.StreamFormat
+import Orchestra.UsageLimits
 import Lean.Data.Json
 
 open Lean (Json)
 
 namespace Orchestra.AgentDef
+
+/-- Run curl with the given args; return (stdout, exit code). -/
+private def runCurl (args : Array String) : IO (String × UInt32) := do
+  let child ← IO.Process.spawn {
+    cmd := "curl"; args
+    stdout := .piped; stderr := .null; stdin := .null
+  }
+  let out ← child.stdout.readToEnd
+  let code ← child.wait
+  return (out, code)
+
+/-- Find the value of an HTTP response header in curl `-D -` output (case-insensitive). -/
+private def findHeader (output : String) (name : String) : Option String :=
+  output.splitOn "\n" |>.findSome? fun line =>
+    if line.toLower.startsWith (name.toLower ++ ":") then
+      some (line.drop (name.length + 1)).trimAscii.toString
+    else none
+
+/-- Return the earliest reset timestamp among all exhausted rate-limit buckets, or `none`
+    if every bucket still has remaining capacity.  Checks the standard Anthropic headers for
+    requests, tokens, input-tokens, and output-tokens, plus any model-specific variants
+    (e.g. weekly Sonnet / weekly all-models limits). -/
+private def exhaustedResetTime (headers : String) : Option String :=
+  let buckets := [
+    -- Per-minute / per-day limits
+    "requests", "tokens", "input-tokens", "output-tokens"
+  ]
+  -- Collect the reset times of all exhausted buckets.
+  let resetTimes := buckets.filterMap fun bucket =>
+    let remKey := s!"anthropic-ratelimit-{bucket}-remaining"
+    let rstKey := s!"anthropic-ratelimit-{bucket}-reset"
+    match findHeader headers remKey with
+    | none => none
+    | some rem =>
+      if rem.trim == "0" then findHeader headers rstKey
+      else none
+  -- Also capture any model-specific limit headers (e.g. weekly Sonnet-only, weekly all-models).
+  -- These follow the pattern: anthropic-ratelimit-<model-slug>-tokens-remaining
+  let modelSpecific := headers.splitOn "\n" |>.filterMap fun line =>
+    let lower := line.toLower
+    if lower.startsWith "anthropic-ratelimit-" && lower.contains "-remaining:" then
+      let parts := lower.splitOn "-remaining:"
+      let remStr := parts.getD 1 "" |>.trim
+      if remStr == "0" then
+        -- Derive the reset key by replacing -remaining: with -reset:
+        let resetLine := line.replace "-remaining:" "-reset:"
+        let resetVal := resetLine.splitOn "-reset:" |>.getD 1 "" |>.trim
+        if resetVal.isEmpty then none else some resetVal
+      else none
+    else none
+  let allResets := resetTimes ++ modelSpecific
+  -- Return the earliest reset time (lexicographic ISO 8601 comparison is correct).
+  allResets.foldl (fun acc t => match acc with | none => some t | some a => some (min a t)) none
+
+/-- Proactively query the Anthropic API to check whether any usage limit is currently
+    exhausted.  Makes a minimal probe request (1 output token) and inspects the
+    rate-limit response headers for all limit types:
+      • per-minute request / token limits
+      • weekly all-models limits
+      • weekly per-model limits (e.g. Sonnet-only)
+    A HTTP 429 response means the limit is already exceeded right now.
+    A 200 with any remaining-count of 0 means we are at the edge.
+    Returns `some resetTime` if the auth source should be blocked, `none` otherwise. -/
+private def queryClaudeUsageLimits (src : AuthSource) : IO (Option String) := do
+  let (authHeader, baseUrl) := match src.kind with
+    | .oauthToken token => (s!"Authorization: Bearer {token}", "https://api.anthropic.com")
+    | .apiKey key mBase => (s!"x-api-key: {key}", mBase.getD "https://api.anthropic.com")
+  -- Use claude-haiku for the probe: cheapest model, minimises cost and quota impact.
+  let body := "{\"model\":\"claude-haiku-4-5-20251001\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\".\"}]}"
+  let (output, _) ← runCurl #[
+    "-s", "-D", "-", "-o", "/dev/null",
+    "-X", "POST",
+    "-H", authHeader,
+    "-H", "anthropic-version: 2023-06-01",
+    "-H", "content-type: application/json",
+    "-d", body,
+    s!"{baseUrl}/v1/messages"
+  ]
+  -- Parse HTTP status from the first line of the header dump.
+  let statusLine := (output.splitOn "\r\n").headD ((output.splitOn "\n").headD "")
+  let httpStatus := (statusLine.splitOn " ").getD 1 ""
+  match httpStatus with
+  | "429" =>
+    -- Currently rate-limited: pick the earliest reset from the response headers.
+    let resetTime :=
+      exhaustedResetTime output
+        |>.orElse (findHeader output "retry-after")
+        |>.orElse (findHeader output "x-ratelimit-reset")
+    match resetTime with
+    | some t => return some t
+    | none   => return some (← UsageLimits.estimateResetTime)
+  | "200" =>
+    -- Request succeeded; check whether any bucket is already at zero.
+    return exhaustedResetTime output
+  | _ =>
+    -- Unexpected error (auth failure, network issue, etc.) — don't block.
+    return none
 
 /-- The Claude coding agent backend. -/
 def claude : AgentDef where
@@ -56,5 +154,6 @@ def claude : AgentDef where
       match baseUrl with
       | some url => vars.push ("ANTHROPIC_BASE_URL", url)
       | none => vars
+  checkCurrentUsageLimits := queryClaudeUsageLimits
 
 end Orchestra.AgentDef

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -255,18 +255,26 @@ def loadAllEntries : IO (Array QueueEntry) := do
         result := result.push e
   return result.qsort (fun a b => a.id > b.id)
 
-/-- Return the next pending entry to run.
-    Entries are ordered by priority (higher first), with older entries breaking ties.
-    Returns none if no pending entries exist. -/
-def nextPending : IO (Option QueueEntry) := do
+-- Cascade cancellation
+
+/-- Normalize backend: treat `none` and `some "claude"` as the same backend. -/
+private def effectiveBackend (backend : Option String) : String :=
+  backend.getD "claude"
+
+/-- Return the next pending entry to run, skipping entries whose (backend, authSource) pair
+    appears in `blocked`. Entries are ordered by: unblocked first, then priority (higher first),
+    with older entries breaking ties. Returns none if no eligible pending entries exist. -/
+def nextPending (blocked : Array (String × Option String) := #[]) : IO (Option QueueEntry) := do
   let all ← loadAllEntries
-  let pending := all.filter (fun e => e.status == .pending)
-  if pending.isEmpty then return none
-  -- Find the maximum priority
-  let maxPri := pending.foldl (·.max ·.priority) 0
+  let pending := all.filter (·.status == .pending)
+  let eligible := pending.filter fun e =>
+    !blocked.any fun (b, as) => effectiveBackend e.backend == b && e.authSource == as
+  if eligible.isEmpty then return none
+  -- Find the maximum priority among eligible entries
+  let maxPri := eligible.foldl (·.max ·.priority) 0
   -- Among entries with max priority, pick the oldest (last in newest-first array)
-  let maxPriEntries := pending.filter (·.priority == maxPri)
-  return (maxPriEntries.back? |>.filter (·.priority == maxPri))
+  let maxPriEntries := eligible.filter (·.priority == maxPri)
+  return maxPriEntries.back?
 
 -- PID file management
 
@@ -290,12 +298,6 @@ def daemonRunning : IO Bool := do
   | none => return false
   | some pid =>
     return ← (System.FilePath.mk s!"/proc/{pid}").pathExists
-
--- Cascade cancellation
-
-/-- Normalize backend: treat `none` and `some "claude"` as the same backend. -/
-private def effectiveBackend (backend : Option String) : String :=
-  backend.getD "claude"
 
 /-- Cancel all pending entries that have continuesFrom = taskId, then recurse. -/
 partial def cancelDependents (taskId : String) : IO Unit := do

--- a/Orchestra/UsageLimits.lean
+++ b/Orchestra/UsageLimits.lean
@@ -1,0 +1,135 @@
+import Lean.Data.Json
+import Orchestra.TaskStore
+
+open Lean (Json FromJson ToJson)
+
+namespace Orchestra.UsageLimits
+
+/-- Records that a (backend, authSource) pair has hit its usage limit. -/
+structure BlockedSource where
+  /-- The agent backend (e.g., "claude", "vibe"). -/
+  backend    : String
+  /-- The auth source label. `none` means the default/unspecified source. -/
+  authSource : Option String
+  /-- When the limit was hit (ISO 8601 UTC). -/
+  blockedAt  : String
+  /-- When the limit is expected to reset (ISO 8601 UTC).
+      If `none`, the source stays blocked until cleared manually or daemon restart. -/
+  resetAt    : Option String
+deriving Repr
+
+instance : ToJson BlockedSource where
+  toJson s :=
+    let fields : List (String × Json) := [
+      ("backend",    s.backend),
+      ("blocked_at", s.blockedAt)
+    ]
+    let fields := if let some a := s.authSource then fields ++ [("auth_source", Json.str a)] else fields
+    let fields := if let some r := s.resetAt    then fields ++ [("reset_at",    Json.str r)] else fields
+    Json.mkObj fields
+
+instance : FromJson BlockedSource where
+  fromJson? j := do
+    let backend   ← j.getObjValAs? String "backend"
+    let blockedAt ← j.getObjValAs? String "blocked_at"
+    let authSource := j.getObjValAs? String "auth_source" |>.toOption
+    let resetAt    := j.getObjValAs? String "reset_at"    |>.toOption
+    return { backend, authSource, blockedAt, resetAt }
+
+private def storePath : IO System.FilePath := do
+  match ← IO.getEnv "HOME" with
+  | some h => return System.FilePath.mk h / ".agent" / "queue" / "usage_limits.json"
+  | none   => throw (.userError "HOME not set")
+
+def loadBlocked : IO (Array BlockedSource) := do
+  let path ← storePath
+  if !(← path.pathExists) then return #[]
+  let contents ← IO.FS.readFile path
+  match Json.parse contents with
+  | .error _ => return #[]
+  | .ok j =>
+    match FromJson.fromJson? j with
+    | .error _ => return #[]
+    | .ok entries => return entries
+
+private def saveBlocked (entries : Array BlockedSource) : IO Unit := do
+  let path ← storePath
+  let dir := path.parent.getD (System.FilePath.mk ".")
+  IO.FS.createDirAll dir
+  IO.FS.writeFile path (Lean.Json.compress (ToJson.toJson entries))
+
+/-- Estimate a reset time 24 hours from now. -/
+def estimateResetTime : IO String := do
+  let child ← IO.Process.spawn {
+    cmd    := "sh"
+    args   := #["-c", "date -u -d @$(( $(date +%s) + 86400 )) '+%Y-%m-%dT%H:%M:%SZ'"]
+    stdout := .piped
+    stderr := .null
+    stdin  := .null
+  }
+  let out ← child.stdout.readToEnd
+  let _   ← child.wait
+  let result := out.trimAscii.toString
+  if result.isEmpty then TaskStore.currentIso8601
+  else return result
+
+/-- Block the given (backend, authSource) pair until resetAt.
+    If resetAt is `none`, uses an estimated 24-hour window. -/
+def blockSource (backend : String) (authSource : Option String)
+    (resetAt : Option String) : IO Unit := do
+  let now ← TaskStore.currentIso8601
+  let resetTime ← match resetAt with
+    | some t => pure t
+    | none   => estimateResetTime
+  let entry : BlockedSource := {
+    backend, authSource
+    blockedAt := now
+    resetAt   := some resetTime
+  }
+  let existing ← loadBlocked
+  let updated :=
+    if existing.any (fun e => e.backend == backend && e.authSource == authSource) then
+      existing.map fun e =>
+        if e.backend == backend && e.authSource == authSource then entry else e
+    else
+      existing.push entry
+  saveBlocked updated
+
+/-- Remove all blocked sources whose reset time has passed. -/
+def clearExpiredBlocks : IO Unit := do
+  let now ← TaskStore.currentIso8601
+  let existing ← loadBlocked
+  let active := existing.filter fun e =>
+    match e.resetAt with
+    | none   => true
+    | some t => t > now
+  if active.size != existing.size then
+    saveBlocked active
+
+/-- Return all currently active (not yet expired) blocked (backend, authSource) pairs. -/
+def blockedSources : IO (Array (String × Option String)) := do
+  let now ← TaskStore.currentIso8601
+  let entries ← loadBlocked
+  return entries.filterMap fun e =>
+    match e.resetAt with
+    | none   => some (e.backend, e.authSource)
+    | some t => if t > now then some (e.backend, e.authSource) else none
+
+/-- Return the reset time for a currently blocked (backend, authSource) pair,
+    or `none` if not blocked. -/
+def resetTimeFor (backend : String) (authSource : Option String) : IO (Option String) := do
+  let now ← TaskStore.currentIso8601
+  let entries ← loadBlocked
+  return entries.findSome? fun e =>
+    if e.backend == backend && e.authSource == authSource then
+      match e.resetAt with
+      | none   => some "unknown"
+      | some t => if t > now then some t else none
+    else none
+
+/-- Clear the blocked state on daemon startup so stale blocks don't prevent work.
+    Expired blocks are removed; unexpired ones are kept so tasks are still delayed. -/
+def clearExpiredBlocksOnStartup : IO Unit :=
+  clearExpiredBlocks
+
+end Orchestra.UsageLimits


### PR DESCRIPTION
Closes #57

## Summary

- **New `Orchestra/UsageLimits.lean`**: Persistent store (`~/.agent/queue/usage_limits.json`) tracking which `(backend, authSource)` pairs have hit their usage limit and when they expect to reset.
- **`Queue.nextPending` updated**: Now accepts a set of blocked `(backend, authSource)` pairs and skips them when selecting the next task, so work on other backends or auth sources continues uninterrupted.
- **Delay instead of cancel**: When a usage limit is hit, the queue daemon calls `UsageLimits.blockSource` with an estimated 24-hour reset window (or an accurate time from the provider API via the new `AgentDef.queryUsageReset` extension point) rather than cancelling all pending same-backend tasks. Tasks remain `pending` and are automatically eligible again once the reset time passes.
- **`AgentDef.queryUsageReset`**: New optional field (default: `fun _ => pure none`) for backends to implement proactive usage limit queries. Allows accurate reset times to be surfaced when the provider API supports it.
- Expired blocks are cleared on daemon startup and at the start of each iteration.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Usage limit hit for backend X | All pending X tasks **cancelled** | All pending X tasks **delayed** until reset |
| Other backends/auth sources | Also cancelled (if same backend) | **Continue running** normally |
| After reset time passes | Manual `queue retry` required | Tasks automatically eligible again |
