### PR TITLE
feat: add comment and report tools

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -122,7 +122,6 @@ private def mcpServerHandler (p : Parsed) : IO UInt32 := do
     privateKeyPath := appConfig.privateKeyPath
     installationId
     pat := appConfig.pat
-    email := appConfig.email
   }
   let (port, _shutdown) ← Server.start serverState
   IO.println s!"MCP server listening on port {port}"

--- a/Main.lean
+++ b/Main.lean
@@ -584,8 +584,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         tools            := entry.tools
         readOnly         := entry.readOnly
         priority         := entry.priority
-        issueNumber      := entry.issueNumber
-        replyToCommentId := entry.replyToCommentId
+        issueNumber := entry.issueNumber
       }
     }
     let cfg ← match entry.configPath with

--- a/Main.lean
+++ b/Main.lean
@@ -386,11 +386,12 @@ private def enqueueHandler (p : Parsed) : IO UInt32 := do
         model         := task.ioTask.model
         continuesFrom, series
         configPath
-        budget       := budgetFlag.orElse (fun _ => task.ioTask.budget)
-        authSource   := task.ioTask.authSource
-        tools        := task.ioTask.tools
-        readOnly     := task.ioTask.readOnly
-        priority     := priorityFlag.getD task.ioTask.priority
+        budget           := budgetFlag.orElse (fun _ => task.ioTask.budget)
+        authSource       := task.ioTask.authSource
+        tools            := task.ioTask.tools
+        readOnly         := task.ioTask.readOnly
+        priority         := priorityFlag.getD task.ioTask.priority
+        issueNumber      := task.ioTask.issueNumber
       }
       let req := Lean.Json.mkObj [("type", "add_task"), ("entry", Lean.ToJson.toJson entry)]
       let _ ← daemonRequest req
@@ -568,21 +569,23 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
     let task : Task := {
       i := entry.inputType, o := entry.outputType
       ioTask := {
-        upstream     := entry.upstream
-        fork         := entry.fork
-        mode         := entry.mode
-        prompt       := entry.prompt
-        agent        := entry.agent
-        systemPrompt := entry.systemPrompt
-        prependPrompt := entry.prependPrompt
-        backend      := entry.backend
-        model        := entry.model
-        budget       := entry.budget
-        memory       := entry.memory
-        authSource   := entry.authSource
-        tools        := entry.tools
-        readOnly     := entry.readOnly
-        priority     := entry.priority
+        upstream         := entry.upstream
+        fork             := entry.fork
+        mode             := entry.mode
+        prompt           := entry.prompt
+        agent            := entry.agent
+        systemPrompt     := entry.systemPrompt
+        prependPrompt    := entry.prependPrompt
+        backend          := entry.backend
+        model            := entry.model
+        budget           := entry.budget
+        memory           := entry.memory
+        authSource       := entry.authSource
+        tools            := entry.tools
+        readOnly         := entry.readOnly
+        priority         := entry.priority
+        issueNumber      := entry.issueNumber
+        replyToCommentId := entry.replyToCommentId
       }
     }
     let cfg ← match entry.configPath with

--- a/Main.lean
+++ b/Main.lean
@@ -122,6 +122,7 @@ private def mcpServerHandler (p : Parsed) : IO UInt32 := do
     privateKeyPath := appConfig.privateKeyPath
     installationId
     pat := appConfig.pat
+    email := appConfig.email
   }
   let (port, _shutdown) ← Server.start serverState
   IO.println s!"MCP server listening on port {port}"

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -327,8 +327,6 @@ structure AppConfig where
   /-- Per-backend authentication source configurations.
       Allows configuring multiple named authentication sources for each agent backend. -/
   agentAuthConfigs : Array AgentAuthConfig := #[]
-  /-- Email address for the `report` tool. When set, agents may send reports to this address. -/
-  email : Option String := none
 deriving Repr
 
 instance : FromJson AppConfig where
@@ -348,10 +346,9 @@ instance : FromJson AppConfig where
     let anthropicAuthToken := j.getObjValAs? String "anthropic_auth_token" |>.toOption
     let authorizedUsers := j.getObjValAs? (List String) "authorized_users" |>.toOption |>.getD []
     let agentAuthConfigs := j.getObjValAs? (Array AgentAuthConfig) "agents" |>.toOption |>.getD #[]
-    let email := j.getObjValAs? String "email" |>.toOption
     return { appId, privateKeyPath, installationId, pat, pluginDirs,
              claudeToken, anthropicApiKey, anthropicBaseUrl, anthropicAuthToken, authorizedUsers,
-             agentAuthConfigs, email }
+             agentAuthConfigs }
 
 structure TaskFile where
   tasks : Array Task

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -206,6 +206,9 @@ structure IOTask (i o : ResultType) where
   /-- Issue or PR number this task was launched from.
       When set, enables the `comment` tool to post to that issue/PR. -/
   issueNumber : Option Nat := none
+  /-- ID of the inline PR review comment to reply to (when triggered by an inline comment).
+      When set, the `comment` tool replies to that inline thread instead of posting a top-level comment. -/
+  replyToCommentId : Option Nat := none
 deriving Repr, Inhabited
 
 /-- The kind of authentication for an agent backend. -/
@@ -301,9 +304,11 @@ instance : FromJson Task where
     let readOnly   := j.getObjValAs? Bool "read_only"        |>.toOption |>.getD false
     let series      := j.getObjValAs? String "series"          |>.toOption
     let priority    := j.getObjValAs? Nat "priority"           |>.toOption |>.getD 10
-    let issueNumber := j.getObjValAs? Nat "issue_number"       |>.toOption
+    let issueNumber      := j.getObjValAs? Nat "issue_number"        |>.toOption
+    let replyToCommentId := j.getObjValAs? Nat "reply_to_comment_id" |>.toOption
     return { i, o, ioTask := { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model,
-                                budget, memory, authSource, tools, readOnly, series, priority, issueNumber } }
+                                budget, memory, authSource, tools, readOnly, series, priority,
+                                issueNumber, replyToCommentId } }
 
 structure AppConfig where
   appId : Nat

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -203,6 +203,9 @@ structure IOTask (i o : ResultType) where
   /-- Priority of this task. Natural number; higher = more important.
       Defaults to 10 if not set. -/
   priority : Nat := 10
+  /-- Issue or PR number this task was launched from.
+      When set, enables the `comment` tool to post to that issue/PR. -/
+  issueNumber : Option Nat := none
 deriving Repr, Inhabited
 
 /-- The kind of authentication for an agent backend. -/
@@ -296,10 +299,11 @@ instance : FromJson Task where
     let authSource := j.getObjValAs? String "auth_source"    |>.toOption
     let tools      := j.getObjValAs? (List String) "tools"   |>.toOption
     let readOnly   := j.getObjValAs? Bool "read_only"        |>.toOption |>.getD false
-    let series     := j.getObjValAs? String "series"         |>.toOption
-    let priority   := j.getObjValAs? Nat "priority"          |>.toOption |>.getD 10
+    let series      := j.getObjValAs? String "series"          |>.toOption
+    let priority    := j.getObjValAs? Nat "priority"           |>.toOption |>.getD 10
+    let issueNumber := j.getObjValAs? Nat "issue_number"       |>.toOption
     return { i, o, ioTask := { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model,
-                                budget, memory, authSource, tools, readOnly, series, priority } }
+                                budget, memory, authSource, tools, readOnly, series, priority, issueNumber } }
 
 structure AppConfig where
   appId : Nat
@@ -322,6 +326,8 @@ structure AppConfig where
   /-- Per-backend authentication source configurations.
       Allows configuring multiple named authentication sources for each agent backend. -/
   agentAuthConfigs : Array AgentAuthConfig := #[]
+  /-- Email address for the `report` tool. When set, agents may send reports to this address. -/
+  email : Option String := none
 deriving Repr
 
 instance : FromJson AppConfig where
@@ -341,9 +347,10 @@ instance : FromJson AppConfig where
     let anthropicAuthToken := j.getObjValAs? String "anthropic_auth_token" |>.toOption
     let authorizedUsers := j.getObjValAs? (List String) "authorized_users" |>.toOption |>.getD []
     let agentAuthConfigs := j.getObjValAs? (Array AgentAuthConfig) "agents" |>.toOption |>.getD #[]
+    let email := j.getObjValAs? String "email" |>.toOption
     return { appId, privateKeyPath, installationId, pat, pluginDirs,
              claudeToken, anthropicApiKey, anthropicBaseUrl, anthropicAuthToken, authorizedUsers,
-             agentAuthConfigs }
+             agentAuthConfigs, email }
 
 structure TaskFile where
   tasks : Array Task

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -206,9 +206,6 @@ structure IOTask (i o : ResultType) where
   /-- Issue or PR number this task was launched from.
       When set, enables the `comment` tool to post to that issue/PR. -/
   issueNumber : Option Nat := none
-  /-- ID of the inline PR review comment to reply to (when triggered by an inline comment).
-      When set, the `comment` tool replies to that inline thread instead of posting a top-level comment. -/
-  replyToCommentId : Option Nat := none
 deriving Repr, Inhabited
 
 /-- The kind of authentication for an agent backend. -/
@@ -304,11 +301,10 @@ instance : FromJson Task where
     let readOnly   := j.getObjValAs? Bool "read_only"        |>.toOption |>.getD false
     let series      := j.getObjValAs? String "series"          |>.toOption
     let priority    := j.getObjValAs? Nat "priority"           |>.toOption |>.getD 10
-    let issueNumber      := j.getObjValAs? Nat "issue_number"        |>.toOption
-    let replyToCommentId := j.getObjValAs? Nat "reply_to_comment_id" |>.toOption
+    let issueNumber := j.getObjValAs? Nat "issue_number" |>.toOption
     return { i, o, ioTask := { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model,
                                 budget, memory, authSource, tools, readOnly, series, priority,
-                                issueNumber, replyToCommentId } }
+                                issueNumber } }
 
 structure AppConfig where
   appId : Nat

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -147,23 +147,25 @@ def createIssueComment (pat : String) (upstream : String) (issueNumber : Nat) (b
   let owner := parts[0]?.getD ""
   let repo  := parts[1]?.getD ""
   let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  let payload := Json.mkObj [("body", body)]
   runCmd "gh" #[
     "api", "--method", "POST",
     s!"/repos/{owner}/{repo}/issues/{issueNumber}/comments",
-    "-f", s!"body={body}"
-  ] (env := env)
+    "--input", "-"
+  ] (input := payload.compress) (env := env)
 
 /-- Reply to an inline PR review comment. -/
-def replyToPrReviewComment (pat : String) (upstream : String) (commentId : Nat) (body : String) : IO String := do
+def replyToPrReviewComment (pat : String) (upstream : String) (prNumber : Nat) (commentId : Nat) (body : String) : IO String := do
   let parts := upstream.splitOn "/"
   let owner := parts[0]?.getD ""
   let repo  := parts[1]?.getD ""
   let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  let payload := Json.mkObj [("body", body)]
   runCmd "gh" #[
     "api", "--method", "POST",
-    s!"/repos/{owner}/{repo}/pulls/comments/{commentId}/replies",
-    "-f", s!"body={body}"
-  ] (env := env)
+    s!"/repos/{owner}/{repo}/pulls/{prNumber}/comments/{commentId}/replies",
+    "--input", "-"
+  ] (input := payload.compress) (env := env)
 
 /-- Get the latest commit SHA of a pull request. -/
 private def getPrLatestCommit (pat : String) (upstream : String) (prNumber : Nat) : IO String := do
@@ -185,15 +187,18 @@ def createPrReviewComment (pat : String) (upstream : String) (prNumber : Nat)
   let repo  := parts[1]?.getD ""
   let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
   let commitId ← getPrLatestCommit pat upstream prNumber
+  let payload := Json.mkObj [
+    ("body", body),
+    ("path", path),
+    ("side", side),
+    ("commit_id", commitId),
+    ("line", Json.num ⟨(line : Int), 0⟩)
+  ]
   runCmd "gh" #[
     "api", "--method", "POST",
     s!"/repos/{owner}/{repo}/pulls/{prNumber}/comments",
-    "-f", s!"body={body}",
-    "-f", s!"path={path}",
-    "-f", s!"side={side}",
-    "-f", s!"commit_id={commitId}",
-    "-F", s!"line={line}"
-  ] (env := env)
+    "--input", "-"
+  ] (input := payload.compress) (env := env)
 
 /-- Post a review (with optional inline comments) on a pull request. -/
 def createPrReview (pat : String) (upstream : String) (prNumber : Nat)
@@ -241,8 +246,9 @@ def getPrReviewCommentPrNumber (pat : String) (upstream : String) (commentId : N
 
 /-- Send a report email via the `sendmail` command. -/
 def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
+  let safeTo := to.replace "\n" " " |>.replace "\r" " "
   let safeSubject := subject.replace "\n" " " |>.replace "\r" " "
-  let message := s!"To: {to}\nSubject: {safeSubject}\n\n{body}"
+  let message := s!"To: {safeTo}\nSubject: {safeSubject}\n\n{body}"
   runCmd' "sendmail" #["-t"] (input := message)
 
 end Orchestra.GitHub

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -244,11 +244,4 @@ def getPrReviewCommentPrNumber (pat : String) (upstream : String) (commentId : N
     | none => throw (.userError s!"unexpected pull_request_url: {trimmed}")
   | none => throw (.userError s!"unexpected pull_request_url: {trimmed}")
 
-/-- Send a report email via the `sendmail` command. -/
-def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
-  let safeTo := to.replace "\n" " " |>.replace "\r" " "
-  let safeSubject := subject.replace "\n" " " |>.replace "\r" " "
-  let message := s!"To: {safeTo}\nSubject: {safeSubject}\n\n{body}"
-  runCmd' "sendmail" #["-t"] (input := message)
-
 end Orchestra.GitHub

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -202,6 +202,8 @@ def createPrReview (pat : String) (upstream : String) (prNumber : Nat)
   let owner := parts[0]?.getD ""
   let repo  := parts[1]?.getD ""
   let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  let commitId ← if comments.isEmpty then pure ""
+                 else getPrLatestCommit pat upstream prNumber
   let commentsJson := comments.map fun c =>
     Json.mkObj [
       ("path", c.path),
@@ -209,20 +211,38 @@ def createPrReview (pat : String) (upstream : String) (prNumber : Nat)
       ("body", c.body),
       ("side", c.side)
     ]
-  let payload := Json.mkObj [
-    ("body", body),
-    ("event", "COMMENT"),
-    ("comments", .arr commentsJson)
-  ]
+  let baseFields : List (String × Json) :=
+    [("body", body), ("event", "COMMENT"), ("comments", Json.arr commentsJson)]
+  let payload := Json.mkObj (
+    baseFields ++ if commitId.isEmpty then [] else [("commit_id", Json.str commitId)])
   runCmd "gh" #[
     "api", "--method", "POST",
     s!"/repos/{owner}/{repo}/pulls/{prNumber}/reviews",
     "--input", "-"
   ] (input := payload.compress) (env := env)
 
+/-- Return the pull-request number that a review comment belongs to. -/
+def getPrReviewCommentPrNumber (pat : String) (upstream : String) (commentId : Nat) : IO Nat := do
+  let parts := upstream.splitOn "/"
+  let owner := parts[0]?.getD ""
+  let repo  := parts[1]?.getD ""
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  let url ← runCmd "gh" #[
+    "api",
+    s!"/repos/{owner}/{repo}/pulls/comments/{commentId}",
+    "--jq", ".pull_request_url"
+  ] (env := env)
+  let trimmed : String := url.trimAscii.toString
+  match trimmed.splitOn "/" |>.getLast? with
+  | some s => match s.toNat? with
+    | some n => return n
+    | none => throw (.userError s!"unexpected pull_request_url: {trimmed}")
+  | none => throw (.userError s!"unexpected pull_request_url: {trimmed}")
+
 /-- Send a report email via the `sendmail` command. -/
 def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
-  let message := s!"To: {to}\nSubject: {subject}\n\n{body}"
+  let safeSubject := subject.replace "\n" " " |>.replace "\r" " "
+  let message := s!"To: {to}\nSubject: {safeSubject}\n\n{body}"
   runCmd' "sendmail" #["-t"] (input := message)
 
 end Orchestra.GitHub

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -179,6 +179,19 @@ def createPrReviewComment (pat : String) (upstream : String) (prNumber : Nat)
     "-F", s!"line={line}"
   ] (env := env)
 
+/-- Post a review (body only, no approval/rejection) on a pull request. -/
+def createPrReview (pat : String) (upstream : String) (prNumber : Nat) (body : String) : IO String := do
+  let parts := upstream.splitOn "/"
+  let owner := parts[0]?.getD ""
+  let repo  := parts[1]?.getD ""
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  runCmd "gh" #[
+    "api", "--method", "POST",
+    s!"/repos/{owner}/{repo}/pulls/{prNumber}/reviews",
+    "-f", s!"body={body}",
+    "-f", "event=COMMENT"
+  ] (env := env)
+
 /-- Send a report email via the `sendmail` command. -/
 def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
   let message := s!"To: {to}\nSubject: {subject}\n\n{body}"

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -125,4 +125,21 @@ def getPrReviewThreads (upstream : String) (prNumber : Nat) (pat : String) : IO 
   | .error e => throw (.userError s!"failed to parse GraphQL response: {e}")
   | .ok j => return j
 
+/-- Post a comment on an issue or pull request. -/
+def createIssueComment (pat : String) (upstream : String) (issueNumber : Nat) (body : String) : IO String := do
+  let parts := upstream.splitOn "/"
+  let owner := parts[0]?.getD ""
+  let repo  := parts[1]?.getD ""
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  runCmd "gh" #[
+    "api", "--method", "POST",
+    s!"/repos/{owner}/{repo}/issues/{issueNumber}/comments",
+    "-f", s!"body={body}"
+  ] (env := env)
+
+/-- Send a report email via the `sendmail` command. -/
+def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
+  let message := s!"To: {to}\nSubject: {subject}\n\n{body}"
+  runCmd' "sendmail" #["-t"] (input := message)
+
 end Orchestra.GitHub

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -149,6 +149,36 @@ def replyToPrReviewComment (pat : String) (upstream : String) (commentId : Nat) 
     "-f", s!"body={body}"
   ] (env := env)
 
+/-- Get the latest commit SHA of a pull request. -/
+private def getPrLatestCommit (pat : String) (upstream : String) (prNumber : Nat) : IO String := do
+  let parts := upstream.splitOn "/"
+  let owner := parts[0]?.getD ""
+  let repo  := parts[1]?.getD ""
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  runCmd "gh" #[
+    "api",
+    s!"/repos/{owner}/{repo}/pulls/{prNumber}",
+    "--jq", ".head.sha"
+  ] (env := env)
+
+/-- Create a new inline PR review comment on a specific file and line. -/
+def createPrReviewComment (pat : String) (upstream : String) (prNumber : Nat)
+    (body path : String) (line : Nat) (side : String) : IO String := do
+  let parts := upstream.splitOn "/"
+  let owner := parts[0]?.getD ""
+  let repo  := parts[1]?.getD ""
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  let commitId ← getPrLatestCommit pat upstream prNumber
+  runCmd "gh" #[
+    "api", "--method", "POST",
+    s!"/repos/{owner}/{repo}/pulls/{prNumber}/comments",
+    "-f", s!"body={body}",
+    "-f", s!"path={path}",
+    "-f", s!"side={side}",
+    "-f", s!"commit_id={commitId}",
+    "-F", s!"line={line}"
+  ] (env := env)
+
 /-- Send a report email via the `sendmail` command. -/
 def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
   let message := s!"To: {to}\nSubject: {subject}\n\n{body}"

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -137,6 +137,18 @@ def createIssueComment (pat : String) (upstream : String) (issueNumber : Nat) (b
     "-f", s!"body={body}"
   ] (env := env)
 
+/-- Reply to an inline PR review comment. -/
+def replyToPrReviewComment (pat : String) (upstream : String) (commentId : Nat) (body : String) : IO String := do
+  let parts := upstream.splitOn "/"
+  let owner := parts[0]?.getD ""
+  let repo  := parts[1]?.getD ""
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  runCmd "gh" #[
+    "api", "--method", "POST",
+    s!"/repos/{owner}/{repo}/pulls/comments/{commentId}/replies",
+    "-f", s!"body={body}"
+  ] (env := env)
+
 /-- Send a report email via the `sendmail` command. -/
 def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do
   let message := s!"To: {to}\nSubject: {subject}\n\n{body}"

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -21,8 +21,17 @@ private def runCmd (cmd : String) (args : Array String)
     stderr := .piped
   }
   if let some s := input then
-    child.stdin.putStr s
-    child.stdin.flush
+    -- takeStdin extracts stdin so it can be dropped (closed/EOF) while child is still alive
+    let (stdinHandle, child') ← child.takeStdin
+    stdinHandle.putStr s
+    stdinHandle.flush
+    -- stdinHandle drops here, signaling EOF to the child process
+    let stdout ← child'.stdout.readToEnd
+    let stderr ← child'.stderr.readToEnd
+    let code ← child'.wait
+    if code != 0 then
+      throw (.userError s!"{cmd} failed (exit {code}):\n{stderr}")
+    return stdout.trimAscii.toString
   let stdout ← child.stdout.readToEnd
   let stderr ← child.stderr.readToEnd
   let code ← child.wait

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -4,6 +4,13 @@ open Lean (Json FromJson ToJson)
 
 namespace Orchestra.GitHub
 
+/-- An inline review comment to include in a PR review. -/
+structure InlineComment where
+  path : String
+  line : Nat
+  body : String
+  side : String
+
 private def runCmd (cmd : String) (args : Array String)
     (input : Option String := none)
     (env : Array (String × Option String) := #[]) : IO String := do
@@ -179,18 +186,30 @@ def createPrReviewComment (pat : String) (upstream : String) (prNumber : Nat)
     "-F", s!"line={line}"
   ] (env := env)
 
-/-- Post a review (body only, no approval/rejection) on a pull request. -/
-def createPrReview (pat : String) (upstream : String) (prNumber : Nat) (body : String) : IO String := do
+/-- Post a review (with optional inline comments) on a pull request. -/
+def createPrReview (pat : String) (upstream : String) (prNumber : Nat)
+    (body : String) (comments : Array InlineComment := #[]) : IO String := do
   let parts := upstream.splitOn "/"
   let owner := parts[0]?.getD ""
   let repo  := parts[1]?.getD ""
   let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
+  let commentsJson := comments.map fun c =>
+    Json.mkObj [
+      ("path", c.path),
+      ("line", Json.num ⟨(c.line : Int), 0⟩),
+      ("body", c.body),
+      ("side", c.side)
+    ]
+  let payload := Json.mkObj [
+    ("body", body),
+    ("event", "COMMENT"),
+    ("comments", .arr commentsJson)
+  ]
   runCmd "gh" #[
     "api", "--method", "POST",
     s!"/repos/{owner}/{repo}/pulls/{prNumber}/reviews",
-    "-f", s!"body={body}",
-    "-f", "event=COMMENT"
-  ] (env := env)
+    "--input", "-"
+  ] (input := payload.compress) (env := env)
 
 /-- Send a report email via the `sendmail` command. -/
 def sendEmail (to : String) (subject : String) (body : String) : IO Unit := do

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -320,12 +320,6 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
   -- and github-comments sources).
   let issueNumber : Option Nat :=
     vars.find? (fun p => p.1 == "issue_number") |>.map (·.2) |>.bind (·.toNat?)
-  -- For inline PR review comments the comment_id is prefixed with "inline:"; extract
-  -- the numeric ID so the `comment` tool can reply to the specific thread.
-  let replyToCommentId : Option Nat :=
-    vars.find? (fun p => p.1 == "comment_id") |>.map (·.2)
-    |>.bind (fun s =>
-      if s.startsWith "inline:" then (s.drop "inline:".length).toNat? else none)
   IO.eprintln s!"[listener] buildQueueEntry: model={repr action.model} budget={repr action.budget} agent={repr action.agent} priority={action.priority}"
   return {
     id, createdAt, status := .pending,
@@ -345,7 +339,6 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
     readOnly     := action.readOnly
     priority     := action.priority
     issueNumber
-    replyToCommentId
   }
 
 -- GitHub helpers
@@ -534,7 +527,11 @@ def pollSource (source : SourceConfig) (state : ListenerState) (ghToken : String
           let parentUrlField := if inline then "pull_request_url" else "issue_url"
           let parentUrl      := comment.getObjValAs? String parentUrlField |>.toOption |>.getD ""
           let issueNum       := parentUrl.splitOn "/" |>.getLast? |>.getD ""
-          let vars := [("comment_id", idStr), ("body", body), ("author", author),
+          -- For inline comments, also expose the numeric ID as `inline_comment_id` so prompt
+          -- templates can pass it directly to the `comment` tool's `reply_to_comment_id` argument.
+          let inlineCommentId := if inline then toString idNum else ""
+          let vars := [("comment_id", idStr), ("inline_comment_id", inlineCommentId),
+                       ("body", body), ("author", author),
                        ("url", url), ("issue_number", issueNum),
                        ("upstream", entry.upstream), ("fork", entry.fork),
                        ("upstream_escaped", entry.upstream.replace "/" "_"),

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -316,6 +316,16 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
   let fork :=
     let rendered := renderTemplate action.fork vars
     if rendered.isEmpty then lookupVar "fork" else rendered
+  -- Extract issue_number from template vars (set by github-issues, github-pr-reviews,
+  -- and github-comments sources).
+  let issueNumber : Option Nat :=
+    vars.find? (fun p => p.1 == "issue_number") |>.map (·.2) |>.bind (·.toNat?)
+  -- For inline PR review comments the comment_id is prefixed with "inline:"; extract
+  -- the numeric ID so the `comment` tool can reply to the specific thread.
+  let replyToCommentId : Option Nat :=
+    vars.find? (fun p => p.1 == "comment_id") |>.map (·.2)
+    |>.bind (fun s =>
+      if s.startsWith "inline:" then (s.drop "inline:".length).toNat? else none)
   IO.eprintln s!"[listener] buildQueueEntry: model={repr action.model} budget={repr action.budget} agent={repr action.agent} priority={action.priority}"
   return {
     id, createdAt, status := .pending,
@@ -334,6 +344,8 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
     tools        := action.tools
     readOnly     := action.readOnly
     priority     := action.priority
+    issueNumber
+    replyToCommentId
   }
 
 -- GitHub helpers

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -140,6 +140,10 @@ structure ActionConfig where
       single task. Template variables are applied to the workflow's upstream/fork
       before conversion. -/
   workflowPath   : Option String := none
+  /-- Issue/PR number to associate with the task. May be a template string
+      (e.g. `"{{pr_number}}"`) or a literal (e.g. `"69"`). When absent the
+      `issue_number` template variable provided by the event source is used. -/
+  issueNumber    : Option String := none
 
 instance : ToJson ActionConfig where
   toJson a :=
@@ -162,6 +166,7 @@ instance : ToJson ActionConfig where
     let fields := if a.readOnly                   then fields ++ [("read_only",      Json.bool true)]  else fields
     let fields := if a.priority != 10             then fields ++ [("priority",        Json.num a.priority)] else fields
     let fields := if let some p := a.workflowPath then fields ++ [("workflow_path",  Json.str p)]          else fields
+    let fields := if let some n := a.issueNumber  then fields ++ [("issue_number",   Json.str n)]          else fields
     Json.mkObj fields
 
 instance : FromJson ActionConfig where
@@ -190,8 +195,9 @@ instance : FromJson ActionConfig where
     let readOnly := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
     let priority     := j.getObjValAs? Nat    "priority"      |>.toOption |>.getD 10
     let workflowPath := j.getObjValAs? String "workflow_path" |>.toOption
+    let issueNumber  := j.getObjValAs? String "issue_number"  |>.toOption
     return { upstream, fork, mode, promptTemplate, series, backend, model, agent, systemPrompt,
-             budget, memory, authSource, tools, readOnly, priority, workflowPath }
+             budget, memory, authSource, tools, readOnly, priority, workflowPath, issueNumber }
 
 -- Listener config
 
@@ -316,10 +322,12 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
   let fork :=
     let rendered := renderTemplate action.fork vars
     if rendered.isEmpty then lookupVar "fork" else rendered
-  -- Extract issue_number from template vars (set by github-issues, github-pr-reviews,
-  -- and github-comments sources).
+  -- Resolve issue_number: prefer the explicit template field from the action config;
+  -- fall back to the `issue_number` variable supplied by the event source.
   let issueNumber : Option Nat :=
-    vars.find? (fun p => p.1 == "issue_number") |>.map (·.2) |>.bind (·.toNat?)
+    match action.issueNumber with
+    | some tmpl => (renderTemplate tmpl vars).toNat?
+    | none      => vars.find? (fun p => p.1 == "issue_number") |>.map (·.2) |>.bind (·.toNat?)
   IO.eprintln s!"[listener] buildQueueEntry: model={repr action.model} budget={repr action.budget} agent={repr action.agent} priority={action.priority}"
   return {
     id, createdAt, status := .pending,

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -129,9 +129,7 @@ structure QueueEntry where
   /-- Serialized task output, written by the daemon after the task completes. -/
   outputJson    : Option Json    := none
   /-- Issue or PR number this task was launched from. Enables the `comment` tool. -/
-  issueNumber      : Option Nat := none
-  /-- ID of the inline PR review comment to reply to (when triggered by an inline comment). -/
-  replyToCommentId : Option Nat := none
+  issueNumber : Option Nat := none
 
 instance : ToJson QueueEntry where
   toJson e :=
@@ -165,8 +163,7 @@ instance : ToJson QueueEntry where
     let fields := if e.outputType != .unit          then fields ++ [("output_type",      ToJson.toJson e.outputType)]  else fields
     let fields := if let some j := e.inputJson       then fields ++ [("input_json",          j)]                           else fields
     let fields := if let some j := e.outputJson      then fields ++ [("output_json",         j)]                           else fields
-    let fields := if let some n := e.issueNumber     then fields ++ [("issue_number",         Json.num n)]                  else fields
-    let fields := if let some n := e.replyToCommentId then fields ++ [("reply_to_comment_id", Json.num n)]                  else fields
+    let fields := if let some n := e.issueNumber then fields ++ [("issue_number", Json.num n)] else fields
     Json.mkObj fields
 
 instance : FromJson QueueEntry where
@@ -199,13 +196,12 @@ instance : FromJson QueueEntry where
     let outputType     := j.getObjValAs? ResultType "output_type"     |>.toOption |>.getD .unit
     let inputJson        := j.getObjVal?   "input_json"          |>.toOption
     let outputJson       := j.getObjVal?   "output_json"         |>.toOption
-    let issueNumber      := j.getObjValAs? Nat "issue_number"        |>.toOption
-    let replyToCommentId := j.getObjValAs? Nat "reply_to_comment_id" |>.toOption
+    let issueNumber := j.getObjValAs? Nat "issue_number" |>.toOption
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, prependPrompt, backend, model, continuesFrom, series, taskId, configPath,
              budget, memory, authSource, tools, readOnly, priority,
              concertStepKey, concertId, inputType, outputType, inputJson, outputJson,
-             issueNumber, replyToCommentId }
+             issueNumber }
 
 -- Directories and paths
 

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -128,6 +128,10 @@ structure QueueEntry where
   inputJson     : Option Json    := none
   /-- Serialized task output, written by the daemon after the task completes. -/
   outputJson    : Option Json    := none
+  /-- Issue or PR number this task was launched from. Enables the `comment` tool. -/
+  issueNumber      : Option Nat := none
+  /-- ID of the inline PR review comment to reply to (when triggered by an inline comment). -/
+  replyToCommentId : Option Nat := none
 
 instance : ToJson QueueEntry where
   toJson e :=
@@ -159,8 +163,10 @@ instance : ToJson QueueEntry where
     let fields := if let some s := e.concertId      then fields ++ [("concert_id",       Json.str s)]                  else fields
     let fields := if e.inputType != .unit           then fields ++ [("input_type",       ToJson.toJson e.inputType)]   else fields
     let fields := if e.outputType != .unit          then fields ++ [("output_type",      ToJson.toJson e.outputType)]  else fields
-    let fields := if let some j := e.inputJson      then fields ++ [("input_json",       j)]                           else fields
-    let fields := if let some j := e.outputJson     then fields ++ [("output_json",      j)]                           else fields
+    let fields := if let some j := e.inputJson       then fields ++ [("input_json",          j)]                           else fields
+    let fields := if let some j := e.outputJson      then fields ++ [("output_json",         j)]                           else fields
+    let fields := if let some n := e.issueNumber     then fields ++ [("issue_number",         Json.num n)]                  else fields
+    let fields := if let some n := e.replyToCommentId then fields ++ [("reply_to_comment_id", Json.num n)]                  else fields
     Json.mkObj fields
 
 instance : FromJson QueueEntry where
@@ -191,12 +197,15 @@ instance : FromJson QueueEntry where
     let concertId      := j.getObjValAs? String    "concert_id"       |>.toOption
     let inputType      := j.getObjValAs? ResultType "input_type"      |>.toOption |>.getD .unit
     let outputType     := j.getObjValAs? ResultType "output_type"     |>.toOption |>.getD .unit
-    let inputJson      := j.getObjVal?   "input_json"  |>.toOption
-    let outputJson     := j.getObjVal?   "output_json" |>.toOption
+    let inputJson        := j.getObjVal?   "input_json"          |>.toOption
+    let outputJson       := j.getObjVal?   "output_json"         |>.toOption
+    let issueNumber      := j.getObjValAs? Nat "issue_number"        |>.toOption
+    let replyToCommentId := j.getObjValAs? Nat "reply_to_comment_id" |>.toOption
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, prependPrompt, backend, model, continuesFrom, series, taskId, configPath,
              budget, memory, authSource, tools, readOnly, priority,
-             concertStepKey, concertId, inputType, outputType, inputJson, outputJson }
+             concertStepKey, concertId, inputType, outputType, inputJson, outputJson,
+             issueNumber, replyToCommentId }
 
 -- Directories and paths
 

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -32,8 +32,6 @@ structure State where
   outputRef : Option (IO.Ref (Option Json)) := none
   /-- Issue or PR number this task was launched from. Required for the `comment` tool. -/
   issueNumber : Option Nat := none
-  /-- Email address for the `report` tool. -/
-  email : Option String := none
 
 private def log (msg : String) : IO Unit := do
   let err ← IO.getStderr
@@ -189,24 +187,6 @@ private def optionalToolDefs : List (String × Json) := [
       ("required", .arr #["body"])
     ])
   ]),
-  ("report", Json.mkObj [
-    ("name", "report"),
-    ("description", "Send a private report via email to the configured address."),
-    ("inputSchema", Json.mkObj [
-      ("type", "object"),
-      ("properties", Json.mkObj [
-        ("subject", Json.mkObj [
-          ("type", "string"),
-          ("description", "Email subject line.")
-        ]),
-        ("body", Json.mkObj [
-          ("type", "string"),
-          ("description", "Email body text.")
-        ])
-      ]),
-      ("required", .arr #["subject", "body"])
-    ])
-  ])
 ]
 
 private def ioToolDefs (inputType outputType : ResultType) : Array Json :=
@@ -263,7 +243,6 @@ inductive ToolCall where
   | createPr (title : String) (body : String) (head : String) (base : String)
   | getPrComments (prNumber : Nat) (unresolvedOnly : Bool) (excludeOutdated : Bool)
   | comment (action : CommentAction)
-  | report (subject : String) (body : String)
   | getTaskInput
   | submitTaskOutput (value : Json)
   | unknown (name : String)
@@ -343,12 +322,6 @@ private def parseToolCall (name : String) (args : Json) : ToolCall :=
             .parseError "'reply_to_comment_id' and 'path'/'line' are mutually exclusive"
           | none, some _, none   => .parseError "'path' requires 'line'"
           | none, none, some _   => .parseError "'line' requires 'path'"
-  | "report" =>
-    let subject := args.getObjValAs? String "subject" |>.toOption |>.getD ""
-    let body    := args.getObjValAs? String "body"    |>.toOption |>.getD ""
-    if subject.isEmpty then .parseError "missing required 'subject' argument"
-    else if body.isEmpty then .parseError "missing required 'body' argument"
-    else .report subject body
   | "get_task_input" => .getTaskInput
   | "submit_task_output" =>
     match args.getObjVal? "value" with
@@ -518,23 +491,6 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         catch e =>
           log s!"tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
-  | .report subject body =>
-    if !state.allowedTools.contains "report" then
-      log "tool report: denied (not in allowed tools)"
-      return toolContent "report tool is not enabled for this task" (isError := true)
-    match state.email with
-    | none =>
-      log "tool report: no email configured"
-      return toolContent "no email address configured (set 'email' in config)" (isError := true)
-    | some addr =>
-      log s!"tool report: sending to {addr}, subject={repr subject}"
-      try
-        GitHub.sendEmail addr subject body
-        log s!"tool report: ok"
-        return toolContent s!"Report sent to {addr}"
-      catch e =>
-        log s!"tool report: error: {e}"
-        return toolContent (toString e) (isError := true)
   | .getTaskInput =>
     log "tool get_task_input"
     match state.inputJson with

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -248,13 +248,13 @@ private def toolsList (state : State) : Json :=
 /-- The action performed by the `comment` tool. -/
 inductive CommentAction where
   /-- Post a top-level comment on the issue or PR. -/
-  | issue
+  | issue (body : String)
   /-- Post a pull-request review body with optional inline comments (COMMENT event, no approval/rejection). -/
-  | review (inlineComments : Array GitHub.InlineComment)
+  | review (body : String) (inlineComments : Array GitHub.InlineComment)
   /-- Reply to an existing inline PR review comment. -/
-  | replyInline (commentId : Nat)
+  | replyInline (body : String) (commentId : Nat)
   /-- Create a new inline PR review comment on a specific file and line. -/
-  | newInline (path : String) (line : Nat) (side : String)
+  | newInline (comment : GitHub.InlineComment)
 
 /-- A parsed and validated tool call. `parseError` carries an argument validation failure. -/
 inductive ToolCall where
@@ -262,7 +262,7 @@ inductive ToolCall where
   | refreshToken
   | createPr (title : String) (body : String) (head : String) (base : String)
   | getPrComments (prNumber : Nat) (unresolvedOnly : Bool) (excludeOutdated : Bool)
-  | comment (body : String) (action : CommentAction)
+  | comment (action : CommentAction)
   | report (subject : String) (body : String)
   | getTaskInput
   | submitTaskOutput (value : Json)
@@ -331,14 +331,14 @@ private def parseToolCall (name : String) (args : Json) : ToolCall :=
                       let s := item.getObjValAs? String "side" |>.toOption |>.getD "RIGHT"
                       some { path := p, line := l, body := b, side := s }
                     | _, _, _ => none
-            .comment body (.review inlineComments)
+            .comment (.review body inlineComments)
           | _, _, _          =>
             .parseError "'review' is mutually exclusive with 'reply_to_comment_id' and 'path'/'line'"
         else
           match replyToId, path, line with
-          | some cid, none, none => .comment body (.replyInline cid)
-          | none, some p, some l => .comment body (.newInline p l side)
-          | none, none, none     => .comment body .issue
+          | some cid, none, none => .comment (.replyInline body cid)
+          | none, some p, some l => .comment (.newInline { path := p, line := l, body, side })
+          | none, none, none     => .comment (.issue body)
           | some _, _, _         =>
             .parseError "'reply_to_comment_id' and 'path'/'line' are mutually exclusive"
           | none, some _, none   => .parseError "'path' requires 'line'"
@@ -465,7 +465,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
     catch e =>
       log s!"tool get_pr_comments: error: {e}"
       return toolContent (toString e) (isError := true)
-  | .comment body action =>
+  | .comment action =>
     if !state.allowedTools.contains "comment" then
       log "tool comment: denied (not in allowed tools)"
       return toolContent "comment tool is not enabled for this task" (isError := true)
@@ -475,7 +475,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       return toolContent "no issue_number configured for this task" (isError := true)
     | some n =>
       match action with
-      | .issue =>
+      | .issue body =>
         log s!"tool comment: posting to {state.upstream}#{n}"
         try
           let result ← GitHub.createIssueComment state.pat state.upstream n body
@@ -484,7 +484,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         catch e =>
           log s!"tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
-      | .review inlineComments =>
+      | .review body inlineComments =>
         log s!"tool comment: posting review to {state.upstream}#{n} \
           ({inlineComments.size} inline comments)"
         try
@@ -494,19 +494,25 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         catch e =>
           log s!"tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
-      | .replyInline cid =>
+      | .replyInline body cid =>
         log s!"tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
         try
+          let cidPr ← GitHub.getPrReviewCommentPrNumber state.pat state.upstream cid
+          if cidPr ≠ n then
+            log s!"tool comment: comment {cid} belongs to PR #{cidPr}, not #{n}"
+            return toolContent s!"comment {cid} does not belong to issue #{n}" (isError := true)
           let result ← GitHub.replyToPrReviewComment state.pat state.upstream cid body
           log "tool comment: ok"
           return toolContent result
         catch e =>
           log s!"tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
-      | .newInline path line side =>
-        log s!"tool comment: new inline comment on {state.upstream}#{n} {path}:{line} ({side})"
+      | .newInline comment =>
+        log s!"tool comment: new inline comment on {state.upstream}#{n} \
+          {comment.path}:{comment.line} ({comment.side})"
         try
-          let result ← GitHub.createPrReviewComment state.pat state.upstream n body path line side
+          let result ← GitHub.createPrReviewComment state.pat state.upstream n
+            comment.body comment.path comment.line comment.side
           log "tool comment: ok"
           return toolContent result
         catch e =>

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -501,7 +501,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
           if cidPr ≠ n then
             log s!"tool comment: comment {cid} belongs to PR #{cidPr}, not #{n}"
             return toolContent s!"comment {cid} does not belong to issue #{n}" (isError := true)
-          let result ← GitHub.replyToPrReviewComment state.pat state.upstream cid body
+          let result ← GitHub.replyToPrReviewComment state.pat state.upstream n cid body
           log "tool comment: ok"
           return toolContent result
         catch e =>

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -30,6 +30,10 @@ structure State where
   inputJson : Option Json := none
   /-- Mutable cell where the agent stores its typed output via `submit_task_output`. -/
   outputRef : Option (IO.Ref (Option Json)) := none
+  /-- Issue or PR number this task was launched from. Required for the `comment` tool. -/
+  issueNumber : Option Nat := none
+  /-- Email address for the `report` tool. -/
+  email : Option String := none
 
 private def log (msg : String) : IO Unit := do
   let err ← IO.getStderr
@@ -113,6 +117,38 @@ private def optionalToolDefs : List (String × Json) := [
       ]),
       ("required", .arr #["head"])
     ])
+  ]),
+  ("comment", Json.mkObj [
+    ("name", "comment"),
+    ("description", "Post a comment on the issue or pull request this task was launched from."),
+    ("inputSchema", Json.mkObj [
+      ("type", "object"),
+      ("properties", Json.mkObj [
+        ("body", Json.mkObj [
+          ("type", "string"),
+          ("description", "The comment text.")
+        ])
+      ]),
+      ("required", .arr #["body"])
+    ])
+  ]),
+  ("report", Json.mkObj [
+    ("name", "report"),
+    ("description", "Send a private report via email to the configured address."),
+    ("inputSchema", Json.mkObj [
+      ("type", "object"),
+      ("properties", Json.mkObj [
+        ("subject", Json.mkObj [
+          ("type", "string"),
+          ("description", "Email subject line.")
+        ]),
+        ("body", Json.mkObj [
+          ("type", "string"),
+          ("description", "Email body text.")
+        ])
+      ]),
+      ("required", .arr #["subject", "body"])
+    ])
   ])
 ]
 
@@ -158,6 +194,8 @@ inductive ToolCall where
   | refreshToken
   | createPr (title : String) (body : String) (head : String) (base : String)
   | getPrComments (prNumber : Nat) (unresolvedOnly : Bool) (excludeOutdated : Bool)
+  | comment (body : String)
+  | report (subject : String) (body : String)
   | getTaskInput
   | submitTaskOutput (value : Json)
   | unknown (name : String)
@@ -196,6 +234,16 @@ private def parseToolCall (name : String) (args : Json) : ToolCall :=
           let unresolvedOnly  := args.getObjValAs? Bool "unresolved_only"  |>.toOption |>.getD false
           let excludeOutdated := args.getObjValAs? Bool "exclude_outdated" |>.toOption |>.getD false
           .getPrComments prNumInt.toNat unresolvedOnly excludeOutdated
+  | "comment" =>
+    match args.getObjValAs? String "body" |>.toOption with
+    | none => .parseError "missing required 'body' argument"
+    | some body => if body.isEmpty then .parseError "'body' must not be empty" else .comment body
+  | "report" =>
+    let subject := args.getObjValAs? String "subject" |>.toOption |>.getD ""
+    let body    := args.getObjValAs? String "body"    |>.toOption |>.getD ""
+    if subject.isEmpty then .parseError "missing required 'subject' argument"
+    else if body.isEmpty then .parseError "missing required 'body' argument"
+    else .report subject body
   | "get_task_input" => .getTaskInput
   | "submit_task_output" =>
     match args.getObjVal? "value" with
@@ -312,6 +360,40 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
     catch e =>
       log s!"tool get_pr_comments: error: {e}"
       return toolContent (toString e) (isError := true)
+  | .comment body =>
+    if !state.allowedTools.contains "comment" then
+      log "tool comment: denied (not in allowed tools)"
+      return toolContent "comment tool is not enabled for this task" (isError := true)
+    match state.issueNumber with
+    | none =>
+      log "tool comment: no issue number configured"
+      return toolContent "no issue_number configured for this task" (isError := true)
+    | some n =>
+      log s!"tool comment: posting to {state.upstream}#{n}"
+      try
+        let result ← GitHub.createIssueComment state.pat state.upstream n body
+        log s!"tool comment: ok"
+        return toolContent result
+      catch e =>
+        log s!"tool comment: error: {e}"
+        return toolContent (toString e) (isError := true)
+  | .report subject body =>
+    if !state.allowedTools.contains "report" then
+      log "tool report: denied (not in allowed tools)"
+      return toolContent "report tool is not enabled for this task" (isError := true)
+    match state.email with
+    | none =>
+      log "tool report: no email configured"
+      return toolContent "no email address configured (set 'email' in config)" (isError := true)
+    | some addr =>
+      log s!"tool report: sending to {addr}, subject={repr subject}"
+      try
+        GitHub.sendEmail addr subject body
+        log s!"tool report: ok"
+        return toolContent s!"Report sent to {addr}"
+      catch e =>
+        log s!"tool report: error: {e}"
+        return toolContent (toString e) (isError := true)
   | .getTaskInput =>
     log "tool get_task_input"
     match state.inputJson with

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -32,6 +32,9 @@ structure State where
   outputRef : Option (IO.Ref (Option Json)) := none
   /-- Issue or PR number this task was launched from. Required for the `comment` tool. -/
   issueNumber : Option Nat := none
+  /-- ID of the inline PR review comment to reply to (when triggered by an inline comment).
+      When set, the `comment` tool replies to that inline thread instead of posting a top-level comment. -/
+  replyToCommentId : Option Nat := none
   /-- Email address for the `report` tool. -/
   email : Option String := none
 
@@ -369,14 +372,25 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       log "tool comment: no issue number configured"
       return toolContent "no issue_number configured for this task" (isError := true)
     | some n =>
-      log s!"tool comment: posting to {state.upstream}#{n}"
-      try
-        let result ← GitHub.createIssueComment state.pat state.upstream n body
-        log s!"tool comment: ok"
-        return toolContent result
-      catch e =>
-        log s!"tool comment: error: {e}"
-        return toolContent (toString e) (isError := true)
+      match state.replyToCommentId with
+      | some cid =>
+        log s!"tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
+        try
+          let result ← GitHub.replyToPrReviewComment state.pat state.upstream cid body
+          log s!"tool comment: ok"
+          return toolContent result
+        catch e =>
+          log s!"tool comment: error: {e}"
+          return toolContent (toString e) (isError := true)
+      | none =>
+        log s!"tool comment: posting to {state.upstream}#{n}"
+        try
+          let result ← GitHub.createIssueComment state.pat state.upstream n body
+          log s!"tool comment: ok"
+          return toolContent result
+        catch e =>
+          log s!"tool comment: error: {e}"
+          return toolContent (toString e) (isError := true)
   | .report subject body =>
     if !state.allowedTools.contains "report" then
       log "tool report: denied (not in allowed tools)"

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -124,7 +124,9 @@ private def optionalToolDefs : List (String × Json) := [
       "Post a comment on the issue or pull request this task was launched from.\n\n" ++
       "Four modes determined by the arguments provided:\n" ++
       "• Regular comment: provide only `body`.\n" ++
-      "• Pull-request review (single review body, no approval/rejection): provide `body` and set `review` to true.\n" ++
+      "• Pull-request review: provide `body` and set `review` to true. " ++
+        "Optionally include `inline_comments` — an array of `{path, line, body, side}` objects " ++
+        "to attach inline comments to the review (COMMENT event, no approval/rejection).\n" ++
       "• Reply to an existing inline PR review comment: provide `body` and `reply_to_comment_id`.\n" ++
       "• New inline PR review comment on a specific file and line: provide `body`, `path`, and `line`.\n\n" ++
       "`review`, `reply_to_comment_id`, and `path`/`line` are mutually exclusive."),
@@ -140,6 +142,23 @@ private def optionalToolDefs : List (String × Json) := [
           ("description",
             "When true, post body as a pull-request review (COMMENT event) rather than a plain comment. " ++
             "Mutually exclusive with reply_to_comment_id and path/line.")
+        ]),
+        ("inline_comments", Json.mkObj [
+          ("type", "array"),
+          ("description",
+            "Optional list of inline comments to include in the review (only valid with review=true). " ++
+            "Each item must have path (string), line (integer), and body (string); " ++
+            "side (\"LEFT\" or \"RIGHT\", default \"RIGHT\") is optional."),
+          ("items", Json.mkObj [
+            ("type", "object"),
+            ("properties", Json.mkObj [
+              ("path",  Json.mkObj [("type", "string")]),
+              ("line",  Json.mkObj [("type", "integer")]),
+              ("body",  Json.mkObj [("type", "string")]),
+              ("side",  Json.mkObj [("type", "string"), ("enum", .arr #["LEFT", "RIGHT"])])
+            ]),
+            ("required", .arr #["path", "line", "body"])
+          ])
         ]),
         ("reply_to_comment_id", Json.mkObj [
           ("type", "integer"),
@@ -230,8 +249,8 @@ private def toolsList (state : State) : Json :=
 inductive CommentAction where
   /-- Post a top-level comment on the issue or PR. -/
   | issue
-  /-- Post a pull-request review body (COMMENT event, no approval/rejection). -/
-  | review
+  /-- Post a pull-request review body with optional inline comments (COMMENT event, no approval/rejection). -/
+  | review (inlineComments : Array GitHub.InlineComment)
   /-- Reply to an existing inline PR review comment. -/
   | replyInline (commentId : Nat)
   /-- Create a new inline PR review comment on a specific file and line. -/
@@ -296,7 +315,23 @@ private def parseToolCall (name : String) (args : Json) : ToolCall :=
         let side      := args.getObjValAs? String "side"             |>.toOption |>.getD "RIGHT"
         if review then
           match replyToId, path, line with
-          | none, none, none => .comment body .review
+          | none, none, none =>
+            let inlineComments : Array GitHub.InlineComment :=
+              match args.getObjVal? "inline_comments" |>.toOption with
+              | none => #[]
+              | some arr =>
+                match arr.getArr? |>.toOption with
+                | none => #[]
+                | some items =>
+                  items.filterMap fun item =>
+                    match item.getObjValAs? String "path" |>.toOption,
+                          item.getObjValAs? Nat  "line"   |>.toOption,
+                          item.getObjValAs? String "body" |>.toOption with
+                    | some p, some l, some b =>
+                      let s := item.getObjValAs? String "side" |>.toOption |>.getD "RIGHT"
+                      some { path := p, line := l, body := b, side := s }
+                    | _, _, _ => none
+            .comment body (.review inlineComments)
           | _, _, _          =>
             .parseError "'review' is mutually exclusive with 'reply_to_comment_id' and 'path'/'line'"
         else
@@ -449,10 +484,11 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         catch e =>
           log s!"tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
-      | .review =>
-        log s!"tool comment: posting review to {state.upstream}#{n}"
+      | .review inlineComments =>
+        log s!"tool comment: posting review to {state.upstream}#{n} \
+          ({inlineComments.size} inline comments)"
         try
-          let result ← GitHub.createPrReview state.pat state.upstream n body
+          let result ← GitHub.createPrReview state.pat state.upstream n body inlineComments
           log "tool comment: ok"
           return toolContent result
         catch e =>

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -122,11 +122,12 @@ private def optionalToolDefs : List (String × Json) := [
     ("name", "comment"),
     ("description",
       "Post a comment on the issue or pull request this task was launched from.\n\n" ++
-      "Three modes determined by the arguments provided:\n" ++
+      "Four modes determined by the arguments provided:\n" ++
       "• Regular comment: provide only `body`.\n" ++
+      "• Pull-request review (single review body, no approval/rejection): provide `body` and set `review` to true.\n" ++
       "• Reply to an existing inline PR review comment: provide `body` and `reply_to_comment_id`.\n" ++
       "• New inline PR review comment on a specific file and line: provide `body`, `path`, and `line`.\n\n" ++
-      "`reply_to_comment_id` and `path`/`line` are mutually exclusive."),
+      "`review`, `reply_to_comment_id`, and `path`/`line` are mutually exclusive."),
     ("inputSchema", Json.mkObj [
       ("type", "object"),
       ("properties", Json.mkObj [
@@ -134,23 +135,29 @@ private def optionalToolDefs : List (String × Json) := [
           ("type", "string"),
           ("description", "The comment text.")
         ]),
+        ("review", Json.mkObj [
+          ("type", "boolean"),
+          ("description",
+            "When true, post body as a pull-request review (COMMENT event) rather than a plain comment. " ++
+            "Mutually exclusive with reply_to_comment_id and path/line.")
+        ]),
         ("reply_to_comment_id", Json.mkObj [
           ("type", "integer"),
           ("description",
             "ID of the inline PR review comment to reply to. " ++
-            "Mutually exclusive with path and line.")
+            "Mutually exclusive with review, path and line.")
         ]),
         ("path", Json.mkObj [
           ("type", "string"),
           ("description",
             "File path for a new inline review comment. " ++
-            "Required together with line. Mutually exclusive with reply_to_comment_id.")
+            "Required together with line. Mutually exclusive with review and reply_to_comment_id.")
         ]),
         ("line", Json.mkObj [
           ("type", "integer"),
           ("description",
             "Line number for a new inline review comment. " ++
-            "Required together with path. Mutually exclusive with reply_to_comment_id.")
+            "Required together with path. Mutually exclusive with review and reply_to_comment_id.")
         ]),
         ("side", Json.mkObj [
           ("type", "string"),
@@ -223,6 +230,8 @@ private def toolsList (state : State) : Json :=
 inductive CommentAction where
   /-- Post a top-level comment on the issue or PR. -/
   | issue
+  /-- Post a pull-request review body (COMMENT event, no approval/rejection). -/
+  | review
   /-- Reply to an existing inline PR review comment. -/
   | replyInline (commentId : Nat)
   /-- Create a new inline PR review comment on a specific file and line. -/
@@ -280,18 +289,25 @@ private def parseToolCall (name : String) (args : Json) : ToolCall :=
     | some body =>
       if body.isEmpty then .parseError "'body' must not be empty"
       else
+        let review    := args.getObjValAs? Bool "review"              |>.toOption |>.getD false
         let replyToId := args.getObjValAs? Nat "reply_to_comment_id" |>.toOption
         let path      := args.getObjValAs? String "path"             |>.toOption
         let line      := args.getObjValAs? Nat "line"                |>.toOption
         let side      := args.getObjValAs? String "side"             |>.toOption |>.getD "RIGHT"
-        match replyToId, path, line with
-        | some cid, none, none => .comment body (.replyInline cid)
-        | none, some p, some l => .comment body (.newInline p l side)
-        | none, none, none     => .comment body .issue
-        | some _, _, _         =>
-          .parseError "'reply_to_comment_id' and 'path'/'line' are mutually exclusive"
-        | none, some _, none   => .parseError "'path' requires 'line'"
-        | none, none, some _   => .parseError "'line' requires 'path'"
+        if review then
+          match replyToId, path, line with
+          | none, none, none => .comment body .review
+          | _, _, _          =>
+            .parseError "'review' is mutually exclusive with 'reply_to_comment_id' and 'path'/'line'"
+        else
+          match replyToId, path, line with
+          | some cid, none, none => .comment body (.replyInline cid)
+          | none, some p, some l => .comment body (.newInline p l side)
+          | none, none, none     => .comment body .issue
+          | some _, _, _         =>
+            .parseError "'reply_to_comment_id' and 'path'/'line' are mutually exclusive"
+          | none, some _, none   => .parseError "'path' requires 'line'"
+          | none, none, some _   => .parseError "'line' requires 'path'"
   | "report" =>
     let subject := args.getObjValAs? String "subject" |>.toOption |>.getD ""
     let body    := args.getObjValAs? String "body"    |>.toOption |>.getD ""
@@ -428,6 +444,15 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         log s!"tool comment: posting to {state.upstream}#{n}"
         try
           let result ← GitHub.createIssueComment state.pat state.upstream n body
+          log "tool comment: ok"
+          return toolContent result
+        catch e =>
+          log s!"tool comment: error: {e}"
+          return toolContent (toString e) (isError := true)
+      | .review =>
+        log s!"tool comment: posting review to {state.upstream}#{n}"
+        try
+          let result ← GitHub.createPrReview state.pat state.upstream n body
           log "tool comment: ok"
           return toolContent result
         catch e =>

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -32,9 +32,6 @@ structure State where
   outputRef : Option (IO.Ref (Option Json)) := none
   /-- Issue or PR number this task was launched from. Required for the `comment` tool. -/
   issueNumber : Option Nat := none
-  /-- ID of the inline PR review comment to reply to (when triggered by an inline comment).
-      When set, the `comment` tool replies to that inline thread instead of posting a top-level comment. -/
-  replyToCommentId : Option Nat := none
   /-- Email address for the `report` tool. -/
   email : Option String := none
 
@@ -123,13 +120,44 @@ private def optionalToolDefs : List (String × Json) := [
   ]),
   ("comment", Json.mkObj [
     ("name", "comment"),
-    ("description", "Post a comment on the issue or pull request this task was launched from."),
+    ("description",
+      "Post a comment on the issue or pull request this task was launched from.\n\n" ++
+      "Three modes determined by the arguments provided:\n" ++
+      "• Regular comment: provide only `body`.\n" ++
+      "• Reply to an existing inline PR review comment: provide `body` and `reply_to_comment_id`.\n" ++
+      "• New inline PR review comment on a specific file and line: provide `body`, `path`, and `line`.\n\n" ++
+      "`reply_to_comment_id` and `path`/`line` are mutually exclusive."),
     ("inputSchema", Json.mkObj [
       ("type", "object"),
       ("properties", Json.mkObj [
         ("body", Json.mkObj [
           ("type", "string"),
           ("description", "The comment text.")
+        ]),
+        ("reply_to_comment_id", Json.mkObj [
+          ("type", "integer"),
+          ("description",
+            "ID of the inline PR review comment to reply to. " ++
+            "Mutually exclusive with path and line.")
+        ]),
+        ("path", Json.mkObj [
+          ("type", "string"),
+          ("description",
+            "File path for a new inline review comment. " ++
+            "Required together with line. Mutually exclusive with reply_to_comment_id.")
+        ]),
+        ("line", Json.mkObj [
+          ("type", "integer"),
+          ("description",
+            "Line number for a new inline review comment. " ++
+            "Required together with path. Mutually exclusive with reply_to_comment_id.")
+        ]),
+        ("side", Json.mkObj [
+          ("type", "string"),
+          ("description",
+            "Which side of the diff to comment on when creating a new inline review comment " ++
+            "(default: RIGHT)."),
+          ("enum", .arr #["LEFT", "RIGHT"])
         ])
       ]),
       ("required", .arr #["body"])
@@ -191,13 +219,22 @@ private def toolsList (state : State) : Json :=
 
 -- Types
 
+/-- The action performed by the `comment` tool. -/
+inductive CommentAction where
+  /-- Post a top-level comment on the issue or PR. -/
+  | issue
+  /-- Reply to an existing inline PR review comment. -/
+  | replyInline (commentId : Nat)
+  /-- Create a new inline PR review comment on a specific file and line. -/
+  | newInline (path : String) (line : Nat) (side : String)
+
 /-- A parsed and validated tool call. `parseError` carries an argument validation failure. -/
 inductive ToolCall where
   | health
   | refreshToken
   | createPr (title : String) (body : String) (head : String) (base : String)
   | getPrComments (prNumber : Nat) (unresolvedOnly : Bool) (excludeOutdated : Bool)
-  | comment (body : String)
+  | comment (body : String) (action : CommentAction)
   | report (subject : String) (body : String)
   | getTaskInput
   | submitTaskOutput (value : Json)
@@ -240,7 +277,21 @@ private def parseToolCall (name : String) (args : Json) : ToolCall :=
   | "comment" =>
     match args.getObjValAs? String "body" |>.toOption with
     | none => .parseError "missing required 'body' argument"
-    | some body => if body.isEmpty then .parseError "'body' must not be empty" else .comment body
+    | some body =>
+      if body.isEmpty then .parseError "'body' must not be empty"
+      else
+        let replyToId := args.getObjValAs? Nat "reply_to_comment_id" |>.toOption
+        let path      := args.getObjValAs? String "path"             |>.toOption
+        let line      := args.getObjValAs? Nat "line"                |>.toOption
+        let side      := args.getObjValAs? String "side"             |>.toOption |>.getD "RIGHT"
+        match replyToId, path, line with
+        | some cid, none, none => .comment body (.replyInline cid)
+        | none, some p, some l => .comment body (.newInline p l side)
+        | none, none, none     => .comment body .issue
+        | some _, _, _         =>
+          .parseError "'reply_to_comment_id' and 'path'/'line' are mutually exclusive"
+        | none, some _, none   => .parseError "'path' requires 'line'"
+        | none, none, some _   => .parseError "'line' requires 'path'"
   | "report" =>
     let subject := args.getObjValAs? String "subject" |>.toOption |>.getD ""
     let body    := args.getObjValAs? String "body"    |>.toOption |>.getD ""
@@ -363,7 +414,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
     catch e =>
       log s!"tool get_pr_comments: error: {e}"
       return toolContent (toString e) (isError := true)
-  | .comment body =>
+  | .comment body action =>
     if !state.allowedTools.contains "comment" then
       log "tool comment: denied (not in allowed tools)"
       return toolContent "comment tool is not enabled for this task" (isError := true)
@@ -372,21 +423,30 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       log "tool comment: no issue number configured"
       return toolContent "no issue_number configured for this task" (isError := true)
     | some n =>
-      match state.replyToCommentId with
-      | some cid =>
-        log s!"tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
+      match action with
+      | .issue =>
+        log s!"tool comment: posting to {state.upstream}#{n}"
         try
-          let result ← GitHub.replyToPrReviewComment state.pat state.upstream cid body
-          log s!"tool comment: ok"
+          let result ← GitHub.createIssueComment state.pat state.upstream n body
+          log "tool comment: ok"
           return toolContent result
         catch e =>
           log s!"tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
-      | none =>
-        log s!"tool comment: posting to {state.upstream}#{n}"
+      | .replyInline cid =>
+        log s!"tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
         try
-          let result ← GitHub.createIssueComment state.pat state.upstream n body
-          log s!"tool comment: ok"
+          let result ← GitHub.replyToPrReviewComment state.pat state.upstream cid body
+          log "tool comment: ok"
+          return toolContent result
+        catch e =>
+          log s!"tool comment: error: {e}"
+          return toolContent (toString e) (isError := true)
+      | .newInline path line side =>
+        log s!"tool comment: new inline comment on {state.upstream}#{n} {path}:{line} ({side})"
+        try
+          let result ← GitHub.createPrReviewComment state.pat state.upstream n body path line side
+          log "tool comment: ok"
           return toolContent result
         catch e =>
           log s!"tool comment: error: {e}"

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -173,7 +173,6 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     inputJson
     outputRef := some outputRef
     issueNumber := ioTask.issueNumber
-    email       := appConfig.email
   }
   let (port, shutdown) ← Server.start serverState
   IO.println s!"  MCP server on port {port}"

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -172,6 +172,8 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     outputType := o
     inputJson
     outputRef := some outputRef
+    issueNumber := ioTask.issueNumber
+    email := appConfig.email
   }
   let (port, shutdown) ← Server.start serverState
   IO.println s!"  MCP server on port {port}"

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -172,9 +172,8 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     outputType := o
     inputJson
     outputRef := some outputRef
-    issueNumber      := ioTask.issueNumber
-    replyToCommentId := ioTask.replyToCommentId
-    email            := appConfig.email
+    issueNumber := ioTask.issueNumber
+    email       := appConfig.email
   }
   let (port, shutdown) ← Server.start serverState
   IO.println s!"  MCP server on port {port}"

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -172,8 +172,9 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     outputType := o
     inputJson
     outputRef := some outputRef
-    issueNumber := ioTask.issueNumber
-    email := appConfig.email
+    issueNumber      := ioTask.issueNumber
+    replyToCommentId := ioTask.replyToCommentId
+    email            := appConfig.email
   }
   let (port, shutdown) ← Server.start serverState
   IO.println s!"  MCP server on port {port}"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A CLI tool for managing and sandboxing coding agents. It clones repositories,
 authenticates via a GitHub App, runs an agent inside a landrun sandbox, and
-optionally creates pull requests to an upstream repository through a built-in
-MCP server.
+exposes GitHub actions (creating pull requests, posting comments) to the agent
+through a built-in MCP server.
 
 ## prerequisites
 
@@ -159,6 +159,24 @@ Fields:
   `.md`); defaults to `default.md` if present
 - `backend` — `"claude"` (default) or `"vibe"`
 - `model` — optional model override passed to the agent
+
+## MCP tools
+
+The agent has access to the following tools via the built-in MCP server:
+
+- `health` — check that the MCP server is running
+- `refresh_token` — refresh the GitHub App installation token
+- `get_pr_comments` — fetch review threads for a pull request
+- `create_pr` — create a pull request on the upstream repository (requires `mode: "pr"`)
+- `comment` — post a comment on the issue or pull request the task was launched from.
+  Supports four modes:
+  - **regular comment**: provide only `body`
+  - **PR review**: provide `body` and set `review: true`; optionally include `inline_comments`
+  - **reply to inline comment**: provide `body` and `reply_to_comment_id`
+  - **new inline comment**: provide `body`, `path`, and `line`
+
+  The `comment` tool requires the task to carry an `issue_number` (set automatically by the
+  listener when triggered from an issue or pull request).
 
 ## running tasks
 

--- a/README.md
+++ b/README.md
@@ -162,12 +162,14 @@ Fields:
 
 ## MCP tools
 
-The agent has access to the following tools via the built-in MCP server:
+The agent has access to the following tools via the built-in MCP server. `health`, `refresh_token`,
+and `get_pr_comments` are always available; `create_pr` and `comment` must be enabled explicitly by
+adding them to the `tools` list in the task configuration.
 
 - `health` — check that the MCP server is running
 - `refresh_token` — refresh the GitHub App installation token
 - `get_pr_comments` — fetch review threads for a pull request
-- `create_pr` — create a pull request on the upstream repository (requires `mode: "pr"`)
+- `create_pr` — create a pull request on the upstream repository
 - `comment` — post a comment on the issue or pull request the task was launched from.
   Supports four modes:
   - **regular comment**: provide only `body`


### PR DESCRIPTION
Closes #33.

## Summary

- **`comment` tool**: Agents can post a comment on the issue or PR the task was launched from. Requires `issue_number` in the task config and `"comment"` in the `tools` list. Posts via the GitHub REST API using `gh`.

## Configuration

**`comment`** — add `issue_number` to the task and enable the tool:
```json
{
  "issue_number": 42,
  "tools": ["comment"]
}
```