### PR TITLE
feat(config): add additional_sandbox_paths to AppConfig

### DIFF
--- a/Orchestra/AgentDef.lean
+++ b/Orchestra/AgentDef.lean
@@ -7,21 +7,6 @@ open Orchestra.StreamFormat
 
 namespace Orchestra
 
-/-- Filesystem paths to expose inside the landrun sandbox. -/
-structure SandboxPaths where
-  /-- Absolute paths needing read+execute (binaries/libraries). -/
-  rox : List String := []
-  /-- Absolute paths needing read-only access. -/
-  ro : List String := []
-  /-- Absolute paths needing read-write access. -/
-  rw : List String := []
-  /-- Paths relative to $HOME needing read+execute. -/
-  homeRox : List String := []
-  /-- Paths relative to $HOME needing read-write access. -/
-  homeRw : List String := []
-  /-- Additional TCP ports to allow outbound connections to (besides 443 and the MCP server port). -/
-  extraPorts : List UInt16 := []
-
 /-- Describes how to invoke and communicate with a specific coding agent backend. -/
 structure AgentDef where
   /-- The executable name (e.g., "claude"). -/

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -301,6 +301,31 @@ instance : FromJson Task where
     return { i, o, ioTask := { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model,
                                 budget, memory, authSource, tools, readOnly, series, priority } }
 
+/-- Filesystem paths to expose inside the landrun sandbox. -/
+structure SandboxPaths where
+  /-- Absolute paths needing read+execute (binaries/libraries). -/
+  rox : List String := []
+  /-- Absolute paths needing read-only access. -/
+  ro : List String := []
+  /-- Absolute paths needing read-write access. -/
+  rw : List String := []
+  /-- Paths relative to $HOME needing read+execute. -/
+  homeRox : List String := []
+  /-- Paths relative to $HOME needing read-write access. -/
+  homeRw : List String := []
+  /-- Additional TCP ports to allow outbound connections to (besides 443 and the MCP server port). -/
+  extraPorts : List UInt16 := []
+deriving Repr
+
+instance : FromJson SandboxPaths where
+  fromJson? j := do
+    let rox     := j.getObjValAs? (List String) "rox"      |>.toOption |>.getD []
+    let ro      := j.getObjValAs? (List String) "ro"       |>.toOption |>.getD []
+    let rw      := j.getObjValAs? (List String) "rw"       |>.toOption |>.getD []
+    let homeRox := j.getObjValAs? (List String) "home_rox" |>.toOption |>.getD []
+    let homeRw  := j.getObjValAs? (List String) "home_rw"  |>.toOption |>.getD []
+    return { rox, ro, rw, homeRox, homeRw }
+
 structure AppConfig where
   appId : Nat
   privateKeyPath : String
@@ -322,6 +347,10 @@ structure AppConfig where
   /-- Per-backend authentication source configurations.
       Allows configuring multiple named authentication sources for each agent backend. -/
   agentAuthConfigs : Array AgentAuthConfig := #[]
+  /-- Additional sandbox paths to expose to every agent launched by this instance.
+      Merged on top of the agent-backend's built-in paths.
+      Useful for granting rw access to directories like `.cache`. -/
+  additionalSandboxPaths : SandboxPaths := {}
 deriving Repr
 
 instance : FromJson AppConfig where
@@ -341,9 +370,10 @@ instance : FromJson AppConfig where
     let anthropicAuthToken := j.getObjValAs? String "anthropic_auth_token" |>.toOption
     let authorizedUsers := j.getObjValAs? (List String) "authorized_users" |>.toOption |>.getD []
     let agentAuthConfigs := j.getObjValAs? (Array AgentAuthConfig) "agents" |>.toOption |>.getD #[]
+    let additionalSandboxPaths := j.getObjValAs? SandboxPaths "additional_sandbox_paths" |>.toOption |>.getD {}
     return { appId, privateKeyPath, installationId, pat, pluginDirs,
              claudeToken, anthropicApiKey, anthropicBaseUrl, anthropicAuthToken, authorizedUsers,
-             agentAuthConfigs }
+             agentAuthConfigs, additionalSandboxPaths }
 
 structure TaskFile where
   tasks : Array Task

--- a/Orchestra/Sandbox.lean
+++ b/Orchestra/Sandbox.lean
@@ -55,7 +55,9 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
     -- If true, mount the project repository read-only in the sandbox.
     (readOnly : Bool := false)
     -- Additional TCP ports to allow, beyond what the agent backend already opens.
-    (extraPorts : Array Nat := #[]) : IO LaunchResult := do
+    (extraPorts : Array Nat := #[])
+    -- Additional sandbox paths from global app config, merged with the agent-backend's built-in paths.
+    (additionalPaths : SandboxPaths := {}) : IO LaunchResult := do
   -- Run agent-specific MCP setup (writes config files, returns extra env vars)
   let (mcpContext, agentEnv) ← agentDef.setupMcp serverPort model systemPrompt
   let paths := agentDef.sandboxPaths
@@ -86,6 +88,25 @@ def launchAgent (agentDef : AgentDef) (repoPath : System.FilePath) (prompt : Str
   for p in ← expandHomePaths paths.homeRw do
     if ← p.pathExists then
       args := args.push "--rw" |>.push p.toString
+  -- Additional paths from global app config
+  for p in additionalPaths.rox do
+    if ← System.FilePath.pathExists p then
+      args := args.push "--rox" |>.push p
+  for p in additionalPaths.ro do
+    if ← System.FilePath.pathExists p then
+      args := args.push "--ro" |>.push p
+  for p in additionalPaths.rw do
+    if ← System.FilePath.pathExists p then
+      args := args.push "--rw" |>.push p
+  for p in ← expandHomePaths additionalPaths.homeRox do
+    if ← p.pathExists then
+      args := args.push "--rox" |>.push p.toString
+  for p in ← expandHomePaths additionalPaths.homeRw do
+    if ← p.pathExists then
+      args := args.push "--rw" |>.push p.toString
+  for p in additionalPaths.extraPorts do
+    args := args.push "--connect-tcp" |>.push (toString p)
+    args := args.push "--bind-tcp" |>.push (toString p)
   -- Plugin directories (read+execute access)
   for p in pluginDirs do
     if ← System.FilePath.pathExists p then

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -234,6 +234,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       (resume := resume) (budget := ioTask.budget.getD 4.0) (cancelToken := cancelToken)
       (extraEnv := apiKeyEnv) (debugLogFile := debugLogFile) (logFile := taskLogFile)
       (readOnly := ioTask.readOnly) (extraPorts := extraPorts)
+      (additionalPaths := appConfig.additionalSandboxPaths)
     IO.println s!"  Agent exited with code {result.exitCode}"
     sessionId := result.sessionId
     lastResultSubtype := result.resultSubtype


### PR DESCRIPTION
## Summary

- Moves `SandboxPaths` definition from `AgentDef.lean` to `Config.lean` (avoids circular imports)
- Adds `FromJson SandboxPaths` instance supporting `rox`, `ro`, `rw`, `home_rox`, `home_rw` keys
- Adds `additionalSandboxPaths : SandboxPaths` field to `AppConfig`, parsed from `additional_sandbox_paths` in the config JSON
- Merges these additional paths into the sandbox args in `Sandbox.launchAgent` alongside the agent-backend's built-in paths

Example config usage:
```json
{
  "github_app": { ... },
  "additional_sandbox_paths": {
    "rw": ["/home/user/.cache"],
    "home_rw": [".cache"]
  }
}
```

Closes #71