### PR TITLE
ci: only run workflow on pushes to `master` and pull requests

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -2,6 +2,8 @@ name: Lean Action CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Previously, the workflow ran twice on pull requests.