### PR TITLE
refactor: separate config and state into XDG directories

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -1,4 +1,5 @@
 import Orchestra
+import Orchestra.Migrate
 import Cli
 import Std.Sync
 
@@ -477,8 +478,7 @@ private def handleSocketRequest
   try conn.close catch _ => pure ()
 
 private def queueStartHandler (p : Parsed) : IO UInt32 := do
-  let configPath   := p.flag? "config"       |>.map (·.as! String)
-  let listenerDir  := p.flag? "listener_dir" |>.map (·.as! String)
+  let configPath   := p.flag? "config" |>.map (·.as! String)
   let debug        := p.hasFlag "debug"
   let background   := p.hasFlag "background"
   -- Background mode: re-exec as a detached daemon and exit
@@ -642,12 +642,9 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         try releaseClaimOnError catch _ => pure ()
         ConcertManager.signal concertMgr (entry.concertStepKey.getD "") none
   -- Load listener configs and spawn one fiber per listener.
-  let lDir ← match listenerDir with
-    | some d => pure (System.FilePath.mk d)
-    | none   => Listener.listenersDir
-  let listenerConfigs ← Listener.loadAllListenerConfigs lDir
+  let listenerConfigs ← Listener.loadAllListenerConfigs
   if !listenerConfigs.isEmpty then
-    IO.println s!"Loaded {listenerConfigs.size} listener(s) from {lDir}"
+    IO.println s!"Loaded {listenerConfigs.size} listener(s)"
   for lcfg in listenerConfigs do
     let _listenerTask ← IO.asTask (prio := .dedicated) do
       -- Fire immediately on first iteration, then respect the configured interval.
@@ -819,14 +816,10 @@ private def queueListHandler (p : Parsed) : IO UInt32 := do
     IO.println s!"{padRight e.id 16} {padRight e.createdAt 20} {padRight e.fork.toString 28} {padRight status 10} {padRight (toString e.priority) 4} {padRight seriesLabel 16} {concertLabel}"
   return (0 : UInt32)
 
-private def listenerListHandler (p : Parsed) : IO UInt32 := do
-  let listenerDir := p.flag? "listener_dir" |>.map (·.as! String)
-  let lDir ← match listenerDir with
-    | some d => pure (System.FilePath.mk d)
-    | none   => Listener.listenersDir
-  let configs ← Listener.loadAllListenerConfigs lDir
+private def listenerListHandler (_ : Parsed) : IO UInt32 := do
+  let configs ← Listener.loadAllListenerConfigs
   if configs.isEmpty then
-    IO.println s!"No listeners found in {lDir}"
+    IO.println "No listeners configured"
     return (0 : UInt32)
   IO.println s!"{padRight "LISTENER" 24} {padRight "ON" 4} {padRight "INTERVAL" 9} {padRight "LAST CHECKED" 22} PROCESSED"
   IO.println (String.ofList (List.replicate 80 '-'))
@@ -893,7 +886,7 @@ private def queueStatusHandler (_ : Parsed) : IO UInt32 := do
       let seriesLabel := e.series.getD ""
       IO.println s!"{padRight e.id 16} {padRight e.fork.toString 28} {padRight status 9} {padRight (toString e.priority) 8} {padRight seriesLabel 16} {concertLabel}"
   -- Listener status
-  let listenerConfigs ← Listener.loadAllListenerConfigs (← Listener.listenersDir)
+  let listenerConfigs ← Listener.loadAllListenerConfigs
   if !listenerConfigs.isEmpty then
     IO.println ""
     IO.println s!"Listeners: {listenerConfigs.size}"
@@ -938,7 +931,7 @@ private def runCmd' : Cmd := `[Cli|
   "Run coding agent tasks from a task file."
 
   FLAGS:
-    c, config : String; "Path to config file (default: ~/.agent/config.json)"
+    c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
     t, task : Nat; "Run only the task at this index (0-based)"
     d, debug; "Print the landrun command before executing it"
     continues : String; "Continue from a previous task by ID (requires --task with multi-task files)"
@@ -955,7 +948,7 @@ private def mcpServerCmd : Cmd := `[Cli|
   "Start the MCP server and print the port it is listening on."
 
   FLAGS:
-    c, config : String; "Path to config file (default: ~/.agent/config.json)"
+    c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
     allow_pr; "Allow the create_pr tool (disabled by default)"
 
   ARGS:
@@ -1012,7 +1005,7 @@ private def resumeCmd : Cmd := `[Cli|
   "Resume the latest run in a series with a new prompt."
 
   FLAGS:
-    c, config : String; "Path to config file (default: ~/.agent/config.json)"
+    c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
     p, prompt : String; "Prompt for the new agent run"
     d, debug; "Print the landrun command before executing it"
     budget : String; "Maximum spend in USD (default: inherited from previous task, or 4.0)"
@@ -1026,7 +1019,7 @@ private def queueAddCmd : Cmd := `[Cli|
   "Add tasks to the queue from a task file or workflow file, or continue a series with a new prompt."
 
   FLAGS:
-    c, config : String; "Path to config file (default: ~/.agent/config.json)"
+    c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
     t, task : Nat; "Enqueue only the task at this index (0-based, task-file mode only)"
     continues : String; "Continue from a previous task by ID (task-file mode only)"
     series : String; "Assign queued task(s) to a named series (task-file mode only)"
@@ -1045,9 +1038,8 @@ private def queueStartCmd : Cmd := `[Cli|
   "Start the queue daemon. Polls for pending tasks and runs them serially."
 
   FLAGS:
-    c, config : String; "Path to config file (default: ~/.agent/config.json)"
+    c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
     d, debug; "Print the landrun command before executing it"
-    listener_dir : String; "Directory of listener configs (default: ~/.agent/listeners/)"
     b, background; "Run the daemon in the background, detached from the terminal"
 ]
 
@@ -1124,9 +1116,6 @@ private def listenerSubDefault (_ : Parsed) : IO UInt32 := do
 private def listenerListCmd : Cmd := `[Cli|
   list VIA listenerListHandler; ["0.1.0"]
   "List configured listeners and their state."
-
-  FLAGS:
-    listener_dir : String; "Directory of listener configs (default: ~/.agent/listeners/)"
 ]
 
 private def listenerEnableCmd : Cmd := `[Cli|
@@ -1171,6 +1160,19 @@ private def queueCmd : Cmd := `[Cli|
     queueRetryCmd
 ]
 
+private def migrateHandler (_ : Parsed) : IO UInt32 := do
+  try
+    Migrate.run
+    return 0
+  catch e =>
+    IO.eprintln s!"Migration failed: {e}"
+    return 1
+
+private def migrateCmd : Cmd := `[Cli|
+  migrate VIA migrateHandler; ["0.1.0"]
+  "Migrate configuration and state from ~/.agent/ to XDG directories (~/.config/orchestra/ and ~/.local/share/orchestra/)."
+]
+
 private def defaultHandler (_ : Parsed) : IO UInt32 := do
   IO.eprintln "Use a subcommand. Try 'orchestra --help'."
   return 1
@@ -1194,7 +1196,8 @@ def orchestraCmd : Cmd := `[Cli|
     projectCmd;
     issueCmd;
     spawnCmd;
-    rolesCmd
+    rolesCmd;
+    migrateCmd
 ]
 
 def main (args : List String) : IO UInt32 := do

--- a/Orchestra.lean
+++ b/Orchestra.lean
@@ -1,3 +1,5 @@
+import Orchestra.Dirs
+import Orchestra.Migrate
 import Orchestra.AgentDef
 import Orchestra.ConcertManager
 import Orchestra.Agents.Claude

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -1,4 +1,5 @@
 import Lean.Data.Json
+import Orchestra.Dirs
 import Orchestra.Project.Id
 
 open Lean (Json FromJson ToJson)
@@ -50,8 +51,8 @@ instance : ToJson TaskMode where
 
 /-- Controls which memory directories are made available to the agent.
     - `none`    – no memory directories
-    - `global`  – global memory only (`~/.agent/memory/`)
-    - `project` – per-project memory only (`~/.agent/memory/<project>/`)
+    - `global`  – global memory only (`<data>/memory/`)
+    - `project` – per-project memory only (`<data>/memory/<project>/`)
     - `both`    – global and per-project memory (default) -/
 inductive MemoryMode where
   | none
@@ -447,31 +448,33 @@ def loadJsonFile (α : Type) [FromJson α] (path : System.FilePath) : IO α := d
     | .ok v => return v
 
 def loadAppConfig (path : Option System.FilePath := none) : IO AppConfig := do
-  let configPath ← expandHome (path.getD "~/.agent/config.json").toString
+  let configPath : System.FilePath ← match path with
+    | some p => expandHome p.toString
+    | none   => do pure ((← Dirs.configBase) / "config.json")
   loadJsonFile AppConfig configPath
 
 def loadTaskFile (path : System.FilePath) : IO TaskFile :=
   loadJsonFile TaskFile path
 
 /--
-Load a system prompt from `~/.agent/prompts/<name>.md`.
+Load a system prompt from the prompts directory (`<config>/prompts/<name>.md`).
 If `name` is `none`, reads `default.md`. Returns `none` if the file does not exist.
 -/
 def loadSystemPrompt (name : Option String := none) : IO (Option String) := do
   let promptName := name.getD "default"
-  let promptPath ← expandHome s!"~/.agent/prompts/{promptName}.md"
+  let promptPath := (← Dirs.configBase) / "prompts" / s!"{promptName}.md"
   if ← promptPath.pathExists then
     return some (← IO.FS.readFile promptPath)
   else
     return none
 
 /--
-Load a prepend prompt from `~/.agent/prompts/<name>.md`.
+Load a prepend prompt from the prompts directory (`<config>/prompts/<name>.md`).
 If `name` is `none`, reads `default-prepend.md`. Returns `none` if the file does not exist.
 -/
 def loadPrependPrompt (name : Option String := none) : IO (Option String) := do
   let promptName := name.getD "default-prepend"
-  let promptPath ← expandHome s!"~/.agent/prompts/{promptName}.md"
+  let promptPath := (← Dirs.configBase) / "prompts" / s!"{promptName}.md"
   if ← promptPath.pathExists then
     return some (← IO.FS.readFile promptPath)
   else

--- a/Orchestra/Dirs.lean
+++ b/Orchestra/Dirs.lean
@@ -1,0 +1,45 @@
+namespace Orchestra.Dirs
+
+private def getHome : IO System.FilePath := do
+  match ← IO.getEnv "HOME" with
+  | some h => return System.FilePath.mk h
+  | none   => throw (.userError "HOME not set")
+
+/-- XDG config base: $XDG_CONFIG_HOME/orchestra or ~/.config/orchestra -/
+def orchestraConfigDir : IO System.FilePath := do
+  match ← IO.getEnv "XDG_CONFIG_HOME" with
+  | some x => return System.FilePath.mk x / "orchestra"
+  | none   => return (← getHome) / ".config" / "orchestra"
+
+/-- XDG data base: $XDG_DATA_HOME/orchestra or ~/.local/share/orchestra -/
+def orchestraDataDir : IO System.FilePath := do
+  match ← IO.getEnv "XDG_DATA_HOME" with
+  | some x => return System.FilePath.mk x / "orchestra"
+  | none   => return (← getHome) / ".local" / "share" / "orchestra"
+
+private initialize deprecationWarned : IO.Ref Bool ← IO.mkRef false
+
+/--
+Config base with legacy fallback.
+Returns `orchestraConfigDir` if it already exists.
+Falls back to `~/.agent/` with a one-time deprecation warning if the XDG dir is
+absent but the legacy dir is present. Returns `orchestraConfigDir` on a fresh install
+(neither exists yet).
+-/
+def configBase : IO System.FilePath := do
+  let xdgDir ← orchestraConfigDir
+  if ← xdgDir.pathExists then return xdgDir
+  let legacy := (← getHome) / ".agent"
+  if ← legacy.pathExists then
+    unless ← deprecationWarned.get do
+      IO.eprintln s!"[orchestra] WARNING: Config not found at '{xdgDir}'; \
+        falling back to '{legacy}'. Run 'orchestra migrate' to upgrade."
+      deprecationWarned.set true
+    return legacy
+  return xdgDir
+
+/-- Data base: always uses the XDG data dir, no legacy fallback. -/
+def dataBase : IO System.FilePath :=
+  orchestraDataDir
+
+end Orchestra.Dirs

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -266,18 +266,16 @@ instance : FromJson ListenerState where
 
 -- Directories
 
-def listenersDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h / ".agent" / "listeners"
-  | none   => throw (.userError "HOME not set")
+def listenersConfigDir : IO System.FilePath :=
+  return (← Dirs.configBase) / "listeners"
 
-def listenerStateDir : IO System.FilePath := do
-  return (← listenersDir) / "state"
+def listenerStateDir : IO System.FilePath :=
+  return (← Dirs.dataBase) / "listeners" / "state"
 
 -- Config I/O
 
 def loadListenerConfig (name : String) : IO (Option ListenerConfig) := do
-  let path := (← listenersDir) / s!"{name}.json"
+  let path := (← listenersConfigDir) / s!"{name}.json"
   if !(← path.pathExists) then return none
   let raw ← IO.FS.readFile path
   match Json.parse raw with
@@ -288,7 +286,8 @@ def loadListenerConfig (name : String) : IO (Option ListenerConfig) := do
     | .ok cfg  => return some cfg
 
 
-def loadAllListenerConfigs (dir : System.FilePath) : IO (Array ListenerConfig) := do
+def loadAllListenerConfigs : IO (Array ListenerConfig) := do
+  let dir ← listenersConfigDir
   if !(← dir.pathExists) then return #[]
   let entries ← System.FilePath.readDir dir
   let mut configs : Array ListenerConfig := #[]

--- a/Orchestra/Migrate.lean
+++ b/Orchestra/Migrate.lean
@@ -1,0 +1,94 @@
+import Orchestra.Dirs
+
+namespace Orchestra.Migrate
+
+private def runCp (args : Array String) : IO Unit := do
+  let child ← IO.Process.spawn {
+    cmd    := "cp"
+    args
+    stdout := .piped
+    stderr := .piped
+  }
+  let stderr ← child.stderr.readToEnd
+  let code   ← child.wait
+  unless code == 0 do
+    throw (.userError s!"cp failed: {stderr.trimAscii}")
+
+private def copyDir (src dst : System.FilePath) (label : String) : IO Unit := do
+  if !(← src.pathExists) then
+    IO.println s!"  skip  {label} (not found)"; return
+  if ← dst.pathExists then
+    IO.println s!"  skip  {label} (already exists at destination)"; return
+  IO.println s!"  copy  {label}"
+  IO.FS.createDirAll dst
+  runCp #["-r", (src / ".").toString, dst.toString]
+
+private def copyFile (src dst : System.FilePath) (label : String) : IO Unit := do
+  if !(← src.pathExists) then
+    IO.println s!"  skip  {label} (not found)"; return
+  if ← dst.pathExists then
+    IO.println s!"  skip  {label} (already exists at destination)"; return
+  IO.println s!"  copy  {label}"
+  runCp #[src.toString, dst.toString]
+
+private def copyJsonFiles (src dst : System.FilePath) (label : String) : IO Unit := do
+  if !(← src.pathExists) then
+    IO.println s!"  skip  {label} (not found)"; return
+  let entries ← src.readDir
+  let jsonEntries := entries.filter (fun e => e.fileName.endsWith ".json")
+  if jsonEntries.isEmpty then
+    IO.println s!"  skip  {label} (no .json files)"; return
+  IO.FS.createDirAll dst
+  let mut copied := 0
+  for e in jsonEntries do
+    let destFile := dst / e.fileName
+    unless ← destFile.pathExists do
+      runCp #[e.path.toString, destFile.toString]
+      copied := copied + 1
+  let skipped := jsonEntries.size - copied
+  let note := if skipped > 0 then s!" ({skipped} already at destination)" else ""
+  IO.println s!"  copy  {label} ({copied} files{note})"
+
+def run : IO Unit := do
+  let home ← match ← IO.getEnv "HOME" with
+    | some h => pure (System.FilePath.mk h)
+    | none   => throw (.userError "HOME not set")
+  let legacy     := home / ".agent"
+  let configDest ← Dirs.orchestraConfigDir
+  let dataDest   ← Dirs.orchestraDataDir
+
+  unless ← legacy.pathExists do
+    IO.println s!"Nothing to migrate: '{legacy}' does not exist."
+    return
+
+  IO.println s!"Migrating from '{legacy}'"
+  IO.println s!"  Config → {configDest}"
+  IO.println s!"  Data   → {dataDest}"
+  IO.println ""
+
+  IO.FS.createDirAll configDest
+  IO.FS.createDirAll dataDest
+
+  IO.println "Config:"
+  copyFile      (legacy / "config.json") (configDest / "config.json") "config.json"
+  copyJsonFiles (legacy / "listeners")   (configDest / "listeners")   "listeners/*.json"
+  copyDir       (legacy / "prompts")     (configDest / "prompts")     "prompts/"
+  copyDir       (legacy / "roles")       (configDest / "roles")       "roles/"
+
+  IO.println ""
+  IO.println "State:"
+  copyDir (legacy / "tasks")               (dataDest / "tasks")               "tasks/"
+  copyDir (legacy / "queue")               (dataDest / "queue")               "queue/"
+  copyDir (legacy / "series")              (dataDest / "series")              "series/"
+  copyDir (legacy / "concerts")            (dataDest / "concerts")            "concerts/"
+  copyDir (legacy / "listeners" / "state") (dataDest / "listeners" / "state") "listeners/state/"
+  copyDir (legacy / "repos")               (dataDest / "repos")               "repos/"
+  copyDir (legacy / "memory")              (dataDest / "memory")              "memory/"
+  copyDir (legacy / "logs")                (dataDest / "logs")                "logs/"
+  copyDir (legacy / "projects")            (dataDest / "projects")            "projects/"
+
+  IO.println ""
+  IO.println s!"Done. '{legacy}' has been left in place."
+  IO.println s!"After verifying the new setup, you may remove it with:  rm -rf {legacy}"
+
+end Orchestra.Migrate

--- a/Orchestra/Project/Basic.lean
+++ b/Orchestra/Project/Basic.lean
@@ -204,22 +204,17 @@ instance : FromJson Issue where
 /-! ## Filesystem layout
 
 ```
-~/.agent/projects/
+~/.local/share/orchestra/projects/
   <project-id>.json              -- Project record
   <project-id>/
     issues/<issue-id>.json       -- Issue record
-    claims/<issue-id>.json       -- Claim lock (separate file: §4 of plan)
+    claims/<issue-id>.json       -- Claim lock
 ```
 -/
 
-private def homeDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h
-  | none   => throw (.userError "HOME not set")
-
 /-- Optional override for the projects root directory. Tests set this to a
-    temp directory to avoid touching the user's real `~/.agent/projects`.
-    When `none`, paths are derived from `$HOME` as usual. -/
+    temp directory to avoid touching the user's real projects directory.
+    When `none`, paths are derived from the XDG data base. -/
 initialize projectsDirOverride : IO.Ref (Option System.FilePath) ← IO.mkRef none
 
 def setProjectsDirOverride (p : Option System.FilePath) : IO Unit :=
@@ -228,7 +223,7 @@ def setProjectsDirOverride (p : Option System.FilePath) : IO Unit :=
 def projectsDir : IO System.FilePath := do
   match ← projectsDirOverride.get with
   | some p => return p
-  | none   => return (← homeDir) / ".agent" / "projects"
+  | none   => return (← Dirs.dataBase) / "projects"
 
 def projectDir (pid : ProjectId) : IO System.FilePath := do
   return (← projectsDir) / pid.value

--- a/Orchestra/Project/Cli.lean
+++ b/Orchestra/Project/Cli.lean
@@ -414,7 +414,7 @@ def rolesListHandler (p : Parsed) : IO UInt32 := do
     | some pr => pure pr
   let roles ← loadAllRoles project.id
   if roles.isEmpty then
-    IO.println "No roles defined (looked under ~/.agent/projects/<pid>/roles and ~/.agent/roles)."
+    IO.println "No roles defined (looked under <data>/projects/<pid>/roles and <config>/roles)."
     return 0
   IO.println s!"{padRight "ROLE" 18} {padRight "PERMISSIONS" 36} TRIGGER  MAX  PRE-CLAIM"
   IO.println (String.ofList (List.replicate 90 '-'))
@@ -662,7 +662,7 @@ def issueCmd : Cmd := `[Cli|
 
 def spawnCmd : Cmd := `[Cli|
   spawn VIA spawnHandler; ["0.1.0"]
-  "Spawn a task for a role from a role template (~/.agent/roles/<role>.json or per-project)."
+  "Spawn a task for a role from a role template (<config>/roles/<role>.json or per-project)."
 
   FLAGS:
     issue    : String; "Bind the task to this issue (required for hasOpenIssues roles to pre-claim)"

--- a/Orchestra/Project/Role.lean
+++ b/Orchestra/Project/Role.lean
@@ -125,11 +125,6 @@ instance : FromJson Role where
 
 /-! ## Filesystem layout -/
 
-private def homeDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h
-  | none   => throw (.userError "HOME not set")
-
 /-- Optional override for the global roles directory (tests redirect this). -/
 initialize globalRolesDirOverride : IO.Ref (Option System.FilePath) ← IO.mkRef none
 
@@ -139,7 +134,7 @@ def setGlobalRolesDirOverride (p : Option System.FilePath) : IO Unit :=
 def globalRolesDir : IO System.FilePath := do
   match ← globalRolesDirOverride.get with
   | some p => return p
-  | none   => return (← homeDir) / ".agent" / "roles"
+  | none   => return (← Dirs.configBase) / "roles"
 
 def projectRolesDir (pid : ProjectId) : IO System.FilePath := do
   return (← projectDir pid) / "roles"

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -220,10 +220,8 @@ instance : FromJson QueueEntry where
 
 -- Directories and paths
 
-def queueDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h / ".agent" / "queue"
-  | none   => throw (.userError "HOME not set")
+def queueDir : IO System.FilePath :=
+  return (← Dirs.dataBase) / "queue"
 
 def pidFile : IO System.FilePath :=
   return (← queueDir) / "daemon.pid"
@@ -353,10 +351,8 @@ def cancelStaleConcertEntries : IO Unit := do
 
 -- Concert run persistence
 
-def concertsDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h / ".agent" / "concerts"
-  | none   => throw (.userError "HOME not set")
+def concertsDir : IO System.FilePath :=
+  return (← Dirs.dataBase) / "concerts"
 
 def saveConcertRun (run : ConcertRun) : IO Unit := do
   let dir ← concertsDir

--- a/Orchestra/Repo.lean
+++ b/Orchestra/Repo.lean
@@ -39,10 +39,8 @@ private def runGh' (args : Array String) (cwd : Option System.FilePath := none) 
   let _ ← runGh args cwd
 
 /-- Base directory for all agent work. -/
-def workDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h / ".agent" / "repos"
-  | none => throw (.userError "HOME not set")
+def workDir : IO System.FilePath :=
+  return (← Dirs.dataBase) / "repos"
 
 /-- Build a plain GitHub HTTPS URL (no credentials). -/
 private def githubUrl (repo : Repository) : String :=

--- a/Orchestra/RepoConfig.lean
+++ b/Orchestra/RepoConfig.lean
@@ -27,12 +27,17 @@ instance : FromJson RepoConfig where
       j.getObjValAs? ValidationConfig "validation" |>.toOption |>.getD {}
     return { validation }
 
-private def agentDir (repoPath : System.FilePath) : System.FilePath :=
-  repoPath / ".agent"
+/-- Return the per-repo config directory, preferring `.orchestra/` and falling back to `.agent/`. -/
+private def orchestraDir (repoPath : System.FilePath) : IO System.FilePath := do
+  let newDir := repoPath / ".orchestra"
+  if ← newDir.pathExists then return newDir
+  let oldDir := repoPath / ".agent"
+  if ← oldDir.pathExists then return oldDir
+  return newDir
 
-/-- Load `.agent/config.json` from the repository. Returns defaults if absent or unparseable. -/
+/-- Load `.orchestra/config.json` (or `.agent/config.json`) from the repository. Returns defaults if absent or unparseable. -/
 def loadRepoConfig (repoPath : System.FilePath) : IO RepoConfig := do
-  let configPath := agentDir repoPath / "config.json"
+  let configPath := (← orchestraDir repoPath) / "config.json"
   if !(← configPath.pathExists) then return {}
   let contents ← IO.FS.readFile configPath
   match Json.parse contents with
@@ -43,11 +48,11 @@ def loadRepoConfig (repoPath : System.FilePath) : IO RepoConfig := do
     | .ok cfg => return cfg
 
 /--
-Run `.agent/<name>` as a bash script with the repository as the working directory.
+Run `.orchestra/<name>` (or `.agent/<name>`) as a bash script with the repository as the working directory.
 Does nothing if the script does not exist. Throws if the script exits non-zero.
 -/
 def runHook (repoPath : System.FilePath) (name : String) : IO Unit := do
-  let hookPath := agentDir repoPath / name
+  let hookPath := (← orchestraDir repoPath) / name
   if !(← hookPath.pathExists) then return
   let child ← IO.Process.spawn {
     cmd  := "bash"
@@ -61,31 +66,31 @@ def runHook (repoPath : System.FilePath) (name : String) : IO Unit := do
     throw (.userError s!"hook {name} failed with exit code {code}")
 
 /--
-Run `.agent/init.sh` once after the repository is first cloned.
-Completion is recorded in `.agent/.initialized`; subsequent calls are no-ops.
-Does nothing if `.agent/` does not exist.
+Run `.orchestra/init.sh` (or `.agent/init.sh`) once after the repository is first cloned.
+Completion is recorded in the same directory as `.initialized`; subsequent calls are no-ops.
+Does nothing if neither `.orchestra/` nor `.agent/` exists in the repo.
 -/
 def runInitIfNeeded (repoPath : System.FilePath) : IO Unit := do
-  let dir := agentDir repoPath
+  let dir ← orchestraDir repoPath
   if !(← dir.pathExists) then return
   let markerPath := dir / ".initialized"
   if ← markerPath.pathExists then return
   runHook repoPath "init.sh"
   IO.FS.writeFile markerPath ""
 
-/-- Returns `true` if `.agent/validation.sh` exists in the repository. -/
-def hasValidationScript (repoPath : System.FilePath) : IO Bool :=
-  (agentDir repoPath / "validation.sh").pathExists
+/-- Returns `true` if `validation.sh` exists in the repo's `.orchestra/` or `.agent/` directory. -/
+def hasValidationScript (repoPath : System.FilePath) : IO Bool := do
+  return (← (← orchestraDir repoPath) / "validation.sh" |>.pathExists)
 
 /--
-Run `.agent/validation.sh`.
+Run `.orchestra/validation.sh` (or `.agent/validation.sh`).
 Returns `(true, "")` if the script passes (exit 0) or does not exist.
 Returns `(false, output)` if the script exits non-zero, where `output` is the
 combined stdout and stderr of the script. Does not throw.
 -/
 def runValidation (repoPath : System.FilePath) : IO (Bool × String) := do
   if !(← hasValidationScript repoPath) then return (true, "")
-  let hookPath := agentDir repoPath / "validation.sh"
+  let hookPath := (← orchestraDir repoPath) / "validation.sh"
   let child ← IO.Process.spawn {
     cmd  := "bash"
     args := #[hookPath.toString]

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -157,21 +157,18 @@ private def sanitizeProjectName (upstream : Repository) : String :=
 /-- Return the active memory directories for the given mode and upstream repo.
     Creates the directories if they do not yet exist. -/
 private def resolveMemoryDirs (mode : MemoryMode) (upstream : Repository) : IO (Array String) := do
-  match ← IO.getEnv "HOME" with
-  | none => return #[]
-  | some home =>
-    let memBase := System.FilePath.mk home / ".agent" / "memory"
-    let globalDir  := memBase
-    let projectDir := memBase / sanitizeProjectName upstream
-    let dirs : Array System.FilePath :=
-      match mode with
-      | .none    => #[]
-      | .global  => #[globalDir]
-      | .project => #[projectDir]
-      | .both    => #[globalDir, projectDir]
-    for dir in dirs do
-      IO.FS.createDirAll dir
-    return dirs.map (·.toString)
+  let memBase    := (← Dirs.dataBase) / "memory"
+  let globalDir  := memBase
+  let projectDir := memBase / sanitizeProjectName upstream
+  let dirs : Array System.FilePath :=
+    match mode with
+    | .none    => #[]
+    | .global  => #[globalDir]
+    | .project => #[projectDir]
+    | .both    => #[globalDir, projectDir]
+  for dir in dirs do
+    IO.FS.createDirAll dir
+  return dirs.map (·.toString)
 
 /-- Build a system-prompt addition describing the available memory directories. -/
 private def memorySystemPrompt (memoryDirs : Array String) : Option String :=
@@ -415,13 +412,9 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
         let suffix := if attempt == 0 then "" else s!".retry{attempt}"
         pure (some ((← TaskStore.tasksDir) / s!"{taskId}{suffix}.debug.jsonl"))
       else pure none
-    -- Structured JSON log: ~/.agent/logs/{fork}/{taskId}.log (always)
     let taskLogFile : Option System.FilePath ← do
-      match ← IO.getEnv "HOME" with
-      | none => pure none
-      | some home =>
-        let suffix := if attempt == 0 then "" else s!".retry{attempt}"
-        pure (some (System.FilePath.mk home / ".agent" / "logs" / ioTask.fork.toString / s!"{taskId}{suffix}.log"))
+      let suffix := if attempt == 0 then "" else s!".retry{attempt}"
+      pure (some ((← Dirs.dataBase) / "logs" / ioTask.fork.toString / s!"{taskId}{suffix}.log"))
     let result ← Sandbox.launchAgent agentDef repoPath prompt port token
       (debug := debug) (pluginDirs := appConfig.pluginDirs) (memoryDirs := memoryDirs)
       (subAgent := ioTask.agent) (model := ioTask.model) (systemPrompt := systemPrompt)

--- a/Orchestra/TaskStore.lean
+++ b/Orchestra/TaskStore.lean
@@ -124,15 +124,11 @@ instance : FromJson TaskRecord where
 
 -- Directories
 
-def tasksDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h / ".agent" / "tasks"
-  | none   => throw (.userError "HOME not set")
+def tasksDir : IO System.FilePath :=
+  return (← Dirs.dataBase) / "tasks"
 
-def seriesDir : IO System.FilePath := do
-  match ← IO.getEnv "HOME" with
-  | some h => return System.FilePath.mk h / ".agent" / "series"
-  | none   => throw (.userError "HOME not set")
+def seriesDir : IO System.FilePath :=
+  return (← Dirs.dataBase) / "series"
 
 -- ID generation: 16-char lowercase hex from the nanosecond monotonic clock
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The resulting binary is at `.lake/build/bin/orchestra`.
 
 ## configuration
 
-Create `~/.agent/config.json`:
+Create `~/.config/orchestra/config.json`:
 
 ```json
 {
@@ -126,8 +126,8 @@ The legacy flat fields (`claude_token`, `anthropic_api_key`,
 `anthropic_base_url`, `anthropic_auth_token`) still work when no `agents`
 array is present, so existing configurations remain valid.
 
-System prompts can be placed in `~/.agent/prompts/`. The file
-`~/.agent/prompts/default.md` is loaded automatically; named prompts can be
+System prompts can be placed in `~/.config/orchestra/prompts/`. The file
+`~/.config/orchestra/prompts/default.md` is loaded automatically; named prompts can be
 referenced via the `system_prompt` field in a task file.
 
 ## task files
@@ -155,7 +155,7 @@ Fields:
   requests to upstream)
 - `prompt` — instruction sent to the agent
 - `agent` — optional sub-agent name passed to the backend
-- `system_prompt` — optional name of a file in `~/.agent/prompts/` (without
+- `system_prompt` — optional name of a file in `~/.config/orchestra/prompts/` (without
   `.md`); defaults to `default.md` if present
 - `backend` — `"claude"` (default) or `"vibe"`
 - `model` — optional model override passed to the agent
@@ -283,15 +283,15 @@ orchestra queue retry --series my-series
 
 ## per-repository configuration
 
-A repository can provide a `.agent/` directory with optional hooks and a config
+A repository can provide a `.orchestra/` directory with optional hooks and a config
 file:
 
-- `.agent/init.sh` — run once after cloning
-- `.agent/before.sh` — run before each agent launch
-- `.agent/validation.sh` — run after each agent launch; non-zero exit triggers
+- `.orchestra/init.sh` — run once after cloning
+- `.orchestra/before.sh` — run before each agent launch
+- `.orchestra/validation.sh` — run after each agent launch; non-zero exit triggers
   a retry
-- `.agent/after.sh` — run after the validation loop completes
-- `.agent/config.json` — validation settings:
+- `.orchestra/after.sh` — run after the validation loop completes
+- `.orchestra/config.json` — validation settings:
 
 ```json
 {
@@ -305,7 +305,7 @@ file:
 ## listeners
 
 Listeners poll event sources and automatically enqueue tasks. Listener configs
-are JSON files placed in `~/.agent/listeners/`.
+are JSON files placed in `~/.config/orchestra/listeners/`.
 
 Example — respond to issue comments containing a trigger word:
 


### PR DESCRIPTION
Split config and state directories and move them to the appropriate XDG-compatible places: By default this is `.config/orchestra` for the configuration and `.local/share/orchestra` for all state files.

Add a command `orchestra migrate` to put config and state in the new place.