### PR TITLE
feat: issue dependencies

### DIFF
--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -460,9 +460,14 @@ def dispatcherTick (input : DispatcherInput) : Array RoleSpawn := Id.run do
     | .hasOpenIssues =>
       -- Pick the first open issue not already in `spawns` (so we don't try
       -- to spawn two workers for the same issue in one tick).
+      -- Skip issues whose dependencies are not yet all completed.
       let alreadyTargeted : Array String := spawns.filterMap fun s => s.issueId.map (·.value)
+      let completedIds : Array String := input.issues.filterMap fun i =>
+        if i.status == .completed then some i.id.value else none
       let some issue := input.issues.find? (fun i =>
-        i.status == .open && !alreadyTargeted.contains i.id.value)
+        i.status == .open &&
+        !alreadyTargeted.contains i.id.value &&
+        i.dependencies.all (fun dep => completedIds.contains dep.value))
         | continue
       spawns := spawns.push { roleName, issueId := some issue.id }
     | .hasInReviewIssues =>

--- a/Orchestra/Project/Basic.lean
+++ b/Orchestra/Project/Basic.lean
@@ -157,17 +157,19 @@ recovered by scanning the project's issues directory; this avoids
 denormalisation drift across moves and renames. -/
 
 structure Issue where
-  id          : IssueId
-  projectId   : ProjectId
-  parentId    : Option IssueId  := none
-  title       : String
-  description : String
-  status      : IssueStatus     := .open
+  id           : IssueId
+  projectId    : ProjectId
+  parentId     : Option IssueId  := none
+  title        : String
+  description  : String
+  status       : IssueStatus     := .open
   /-- Per-issue override of the project's default target. -/
-  target      : Option RepoTarget := none
-  attachedPRs : Array PRRef     := #[]
-  createdAt   : String
-  updatedAt   : String
+  target       : Option RepoTarget := none
+  attachedPRs  : Array PRRef     := #[]
+  /-- Issues that must be completed before this one can be dispatched. -/
+  dependencies : Array IssueId   := #[]
+  createdAt    : String
+  updatedAt    : String
 deriving Repr, Inhabited
 
 instance : ToJson Issue where
@@ -184,6 +186,7 @@ instance : ToJson Issue where
     let fields := base
     let fields := if let some p := i.parentId then fields ++ [("parent_id", ToJson.toJson p)] else fields
     let fields := if let some t := i.target   then fields ++ [("target",    ToJson.toJson t)] else fields
+    let fields := if !i.dependencies.isEmpty  then fields ++ [("dependencies", Json.arr (i.dependencies.map ToJson.toJson))] else fields
     Json.mkObj fields
 
 instance : FromJson Issue where
@@ -195,11 +198,12 @@ instance : FromJson Issue where
     let status      ← j.getObjValAs? IssueStatus "status"
     let createdAt   ← j.getObjValAs? String "created_at"
     let updatedAt   ← j.getObjValAs? String "updated_at"
-    let parentId    := j.getObjValAs? IssueId "parent_id" |>.toOption
-    let target      := j.getObjValAs? RepoTarget "target"   |>.toOption
-    let attachedPRs := (j.getObjValAs? (Array PRRef) "attached_prs" |>.toOption).getD #[]
+    let parentId     := j.getObjValAs? IssueId "parent_id" |>.toOption
+    let target       := j.getObjValAs? RepoTarget "target"   |>.toOption
+    let attachedPRs  := (j.getObjValAs? (Array PRRef) "attached_prs" |>.toOption).getD #[]
+    let dependencies := (j.getObjValAs? (Array IssueId) "dependencies" |>.toOption).getD #[]
     return { id, projectId, parentId, title, description, status, target, attachedPRs,
-             createdAt, updatedAt }
+             dependencies, createdAt, updatedAt }
 
 /-! ## Filesystem layout
 

--- a/Orchestra/Project/Cli.lean
+++ b/Orchestra/Project/Cli.lean
@@ -260,6 +260,9 @@ def issueShowHandler (p : Parsed) : IO UInt32 := do
     IO.println s!"Title:        {i.title}"
     IO.println s!"Status:       {issueStatusToString i.status}"
     IO.println s!"Target:       {target}"
+    let depsStr := if i.dependencies.isEmpty then "-"
+                   else String.intercalate ", " (i.dependencies.map (·.value)).toList
+    IO.println s!"Dependencies: {depsStr}"
     IO.println s!"Created:      {i.createdAt}"
     IO.println s!"Updated:      {i.updatedAt}"
     if i.attachedPRs.isEmpty then

--- a/Orchestra/Project/Tools.lean
+++ b/Orchestra/Project/Tools.lean
@@ -44,8 +44,10 @@ inductive ProjectTool where
   | getIssue         (issueId : IssueId)
   | createIssue      (projectId : ProjectId) (title description : String)
                      (parentId : Option IssueId) (target : Option RepoTarget)
+                     (dependencies : Array IssueId := #[])
   | updateIssue      (issueId : IssueId) (title description : Option String)
                      (status : Option IssueStatus) (target : Option RepoTarget)
+                     (dependencies : Option (Array IssueId) := none)
   -- work_issues
   | listOpenIssues   (projectId : ProjectId) (targetRepo : Option Repository)
   | claimIssue       (issueId : IssueId)
@@ -110,26 +112,37 @@ def toolDefs : List (String × String × Json) :=
         , ("description",
             "Create a new issue in a project. To create a sub-issue, set parent_id to " ++
             "the parent issue ID. Per-issue target_repo / target_branch override the " ++
-            "project default.")
+            "project default. Use dependency_ids to list issues that must be completed " ++
+            "before this one is dispatched.")
         , ("inputSchema", obj
             [ ("project_id", strProp "Project ID")
             , ("title", strProp "Issue title")
             , ("description", strProp "Issue description (markdown allowed)")
             , ("parent_id", strProp "Optional parent issue ID")
             , ("target_repo", strProp "Optional target repo (owner/name)")
-            , ("target_branch", strProp "Optional target branch") ]
+            , ("target_branch", strProp "Optional target branch")
+            , ("dependency_ids", Json.mkObj
+                [ ("type", "array")
+                , ("description", "Optional list of issue IDs that must be completed before this issue is dispatched")
+                , ("items", Json.mkObj [("type", "string")]) ]) ]
             ["project_id", "title", "description"]) ])
   , (manageIssuesPerm, "update_issue",
       Json.mkObj
         [ ("name", "update_issue")
-        , ("description", "Update an issue's title, description, status, or target.")
+        , ("description",
+            "Update an issue's title, description, status, target, or dependencies. " ++
+            "Pass dependency_ids to replace the full dependency list; omit to leave it unchanged.")
         , ("inputSchema", obj
             [ ("issue_id", strProp "Issue ID")
             , ("title", strProp "New title")
             , ("description", strProp "New description")
             , ("status", strProp "New status (open|claimed|in_review|completed|abandoned)")
             , ("target_repo", strProp "New target repo (owner/name)")
-            , ("target_branch", strProp "New target branch") ]
+            , ("target_branch", strProp "New target branch")
+            , ("dependency_ids", Json.mkObj
+                [ ("type", "array")
+                , ("description", "Replace the dependency list with these issue IDs (issues that must be completed before this one is dispatched)")
+                , ("items", Json.mkObj [("type", "string")]) ]) ]
             ["issue_id"]) ])
     -- work_issues
   , (workIssuesPerm, "list_open_issues",
@@ -270,7 +283,10 @@ def tryParseToolCall (name : String) (args : Json) : Option (Except String Proje
       let parent : Option IssueId :=
         args.getObjValAs? String "parent_id" |>.toOption |>.map (fun s => ⟨s⟩)
       let target  ← parseTarget? args
-      return .createIssue ⟨pid⟩ title descr parent target
+      let dependencies : Array IssueId :=
+        (args.getObjValAs? (Array String) "dependency_ids" |>.toOption).getD #[]
+        |>.map (fun s => ⟨s⟩)
+      return .createIssue ⟨pid⟩ title descr parent target dependencies
   | "update_issue" =>
     some <| do
       let iid ← args.getObjValAs? String "issue_id"
@@ -281,7 +297,9 @@ def tryParseToolCall (name : String) (args : Json) : Option (Except String Proje
         | none => none
         | some s => issueStatusOfString? s
       let target ← parseTarget? args
-      return .updateIssue ⟨iid⟩ title descr status target
+      let dependencies : Option (Array IssueId) :=
+        args.getObjValAs? (Array String) "dependency_ids" |>.toOption |>.map (·.map (⟨·⟩))
+      return .updateIssue ⟨iid⟩ title descr status target dependencies
   | "list_open_issues" =>
     some <| do
       let pid ← args.getObjValAs? String "project_id"
@@ -436,22 +454,25 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
       let prs := i.attachedPRs.map (fun p => s!"  - {p.repo}#{p.number} (branch {p.branch})")
       let children ← childrenOf project.id i.id
       let childLines := children.map (fun c => s!"  - {c.id.value}  [{issueStatusToString c.status}]  {c.title}")
+      let depsStr := if i.dependencies.isEmpty then "-"
+                     else String.intercalate ", " (i.dependencies.map (·.value)).toList
       let header : Array String := #[
-        s!"id:        {i.id.value}",
-        s!"project:   {project.id.value} ({project.name})",
-        s!"parent:    {i.parentId.map (·.value) |>.getD "-"}",
-        s!"title:     {i.title}",
-        s!"status:    {issueStatusToString i.status}",
-        s!"target:    {target}",
-        s!"created:   {i.createdAt}",
-        s!"updated:   {i.updatedAt}",
+        s!"id:           {i.id.value}",
+        s!"project:      {project.id.value} ({project.name})",
+        s!"parent:       {i.parentId.map (·.value) |>.getD "-"}",
+        s!"title:        {i.title}",
+        s!"status:       {issueStatusToString i.status}",
+        s!"target:       {target}",
+        s!"dependencies: {depsStr}",
+        s!"created:      {i.createdAt}",
+        s!"updated:      {i.updatedAt}",
         if i.attachedPRs.isEmpty then "attached_prs: -" else "attached_prs:" ]
       let descrLines := (i.description.splitOn "\n").toArray.map (fun l => s!"  {l}")
       let mut body := header ++ prs
       if !children.isEmpty then body := body ++ #["children:"] ++ childLines
       body := body ++ #["description:"] ++ descrLines
       return content (joinLines body)
-  | .createIssue pid title descr parent target =>
+  | .createIssue pid title descr parent target dependencies =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
     let some project ← loadProject pid
       | return content s!"project {pid.value} not found" (isError := true)
@@ -461,21 +482,22 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     let iid ← freshIssueId
     let issue : Issue :=
       { id := iid, projectId := pid, parentId := parent, title, description := descr
-      , target, createdAt := now, updatedAt := now }
+      , target, dependencies, createdAt := now, updatedAt := now }
     saveIssue issue
     return content s!"created issue {iid.value} in project {pid.value}"
-  | .updateIssue iid title descr status target =>
+  | .updateIssue iid title descr status target dependencies =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
     match ← findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (_, i) =>
       let updated : Issue :=
         { i with
-          title       := title.getD i.title
-          description := descr.getD i.description
-          status      := status.getD i.status
-          target      := match target with | some t => some t | none => i.target
-          updatedAt   := now }
+          title        := title.getD i.title
+          description  := descr.getD i.description
+          status       := status.getD i.status
+          target       := match target with | some t => some t | none => i.target
+          dependencies := dependencies.getD i.dependencies
+          updatedAt    := now }
       saveIssue updated
       return content s!"updated issue {iid.value}"
   -- ---------------- work_issues ----------------


### PR DESCRIPTION
Add a new `dependencies` field to issues. This is an array of issue IDs that need to be completed before this issue can be worked on. The automatic dispatcher respects this field.

Dependencies can be configured at creation time and later through the update issue tool.