### PR TITLE
fix: set parent issue to blocked when creating a child issue with explicit parent

### DIFF
--- a/Orchestra/Project/Tools.lean
+++ b/Orchestra/Project/Tools.lean
@@ -479,6 +479,11 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     if target.isNone && project.defaultTarget.isNone then
       return content
         "project has no default target; pass target_repo and target_branch" (isError := true)
+    if let some parentId := parent then
+      match ← findIssue parentId with
+      | none => return content s!"parent issue {parentId.value} not found" (isError := true)
+      | some (_, parentIssue) =>
+        saveIssue { parentIssue with status := .blocked, updatedAt := now }
     let iid ← freshIssueId
     let issue : Issue :=
       { id := iid, projectId := pid, parentId := parent, title, description := descr


### PR DESCRIPTION
## Summary

- Fixes #85: when `create_issue` is called with an explicit `parent_id`, the parent issue is now set to `.blocked` status
- This matches the behavior of the `split_issue` tool, which already sets the parent to `.blocked`
- Also validates that the parent issue exists before creating the child, returning an error if not found

## Test plan

- [ ] Create a project and an issue
- [ ] Call `create_issue` with `parent_id` set to the existing issue's ID
- [ ] Verify the parent issue's status is now `blocked`
- [ ] Verify the child issue is created successfully with the correct `parentId`
- [ ] Call `create_issue` with a non-existent `parent_id` and verify an error is returned