### PR TITLE
allow commenting on fork PRs

### DIFF
--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -161,7 +161,9 @@ private def optionalToolDefs : List (String × Json) := [
         "to attach inline comments to the review (COMMENT event, no approval/rejection).\n" ++
       "• Reply to an existing inline PR review comment: provide `body` and `reply_to_comment_id`.\n" ++
       "• New inline PR review comment on a specific file and line: provide `body`, `path`, and `line`.\n\n" ++
-      "`review`, `reply_to_comment_id`, and `path`/`line` are mutually exclusive."),
+      "`review`, `reply_to_comment_id`, and `path`/`line` are mutually exclusive.\n\n" ++
+      "Use `target=\"fork\"` when the PR lives in the fork repository rather than upstream " ++
+      "(authenticated by a freshly-minted GitHub App installation token, no PAT required)."),
     ("inputSchema", Json.mkObj [
       ("type", "object"),
       ("properties", Json.mkObj [
@@ -216,6 +218,13 @@ private def optionalToolDefs : List (String × Json) := [
             "Which side of the diff to comment on when creating a new inline review comment " ++
             "(default: RIGHT)."),
           ("enum", .arr #["LEFT", "RIGHT"])
+        ]),
+        ("target", Json.mkObj [
+          ("type", "string"),
+          ("enum", Json.arr #["upstream", "fork"]),
+          ("description",
+            "Which repository hosts the PR. \"upstream\" (default) posts to state.upstream via PAT; " ++
+            "\"fork\" posts to state.fork via the GitHub App installation token.")
         ])
       ]),
       ("required", .arr #["body"])
@@ -292,7 +301,7 @@ inductive ToolCall where
   | createPr (title : String) (body : String) (head : String) (base : String)
              (target : PrTarget)
   | getPrComments (prNumber : Nat) (unresolvedOnly : Bool) (excludeOutdated : Bool)
-  | comment (action : CommentAction)
+  | comment (action : CommentAction) (target : PrTarget)
   | getTaskInput
   | submitTaskOutput (value : Json)
   /-- A project / issue tool from `Orchestra.Project.Tools`. -/
@@ -354,6 +363,15 @@ def parseToolCall (name : String) (args : Json) : ToolCall :=
         let path      := args.getObjValAs? String "path"             |>.toOption
         let line      := args.getObjValAs? Nat "line"                |>.toOption
         let side      := args.getObjValAs? String "side"             |>.toOption |>.getD "RIGHT"
+        let targetStr := args.getObjValAs? String "target"           |>.toOption |>.getD "upstream"
+        let target? : Option PrTarget := match targetStr with
+          | "upstream" => some .upstream
+          | "fork"     => some .fork
+          | _          => none
+        match target? with
+        | none =>
+          .parseError s!"invalid 'target' (expected \"upstream\" or \"fork\", got {repr targetStr})"
+        | some target =>
         if review then
           match replyToId, path, line with
           | none, none, none =>
@@ -372,14 +390,14 @@ def parseToolCall (name : String) (args : Json) : ToolCall :=
                       let s := item.getObjValAs? String "side" |>.toOption |>.getD "RIGHT"
                       some { path := p, line := l, body := b, side := s }
                     | _, _, _ => none
-            .comment (.review body inlineComments)
+            .comment (.review body inlineComments) target
           | _, _, _          =>
             .parseError "'review' is mutually exclusive with 'reply_to_comment_id' and 'path'/'line'"
         else
           match replyToId, path, line with
-          | some cid, none, none => .comment (.replyInline body cid)
-          | none, some p, some l => .comment (.newInline { path := p, line := l, body, side })
-          | none, none, none     => .comment (.issue body)
+          | some cid, none, none => .comment (.replyInline body cid) target
+          | none, some p, some l => .comment (.newInline { path := p, line := l, body, side }) target
+          | none, none, none     => .comment (.issue body) target
           | some _, _, _         =>
             .parseError "'reply_to_comment_id' and 'path'/'line' are mutually exclusive"
           | none, some _, none   => .parseError "'path' requires 'line'"
@@ -475,7 +493,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
     catch e =>
       log s!"tool get_pr_comments: error: {e}"
       return toolContent (toString e) (isError := true)
-  | .comment action =>
+  | .comment action target =>
     if !state.allowedTools.contains "comment" then
       log "tool comment: denied (not in allowed tools)"
       return toolContent "comment tool is not enabled for this task" (isError := true)
@@ -484,50 +502,47 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       log "tool comment: no issue number configured"
       return toolContent "no issue_number configured for this task" (isError := true)
     | some n =>
-      match action with
-      | .issue body =>
-        log s!"tool comment: posting to {state.upstream}#{n}"
-        try
-          let result ← GitHub.createIssueComment state.pat state.upstream n body
+      -- Resolve which repo to target and which token to use.
+      let (repo, tokenIO) : Repository × IO String :=
+        match target with
+        | .upstream => (state.upstream, pure state.pat)
+        | .fork =>
+          (state.fork, do
+            let jwt ← GitHub.createJWT state.appId state.privateKeyPath
+            GitHub.createInstallationToken jwt state.installationId)
+      try
+        let token ← tokenIO
+        match action with
+        | .issue body =>
+          log s!"tool comment: posting to {repo}#{n}"
+          let result ← GitHub.createIssueComment token repo n body
           log "tool comment: ok"
           return toolContent result
-        catch e =>
-          log s!"tool comment: error: {e}"
-          return toolContent (toString e) (isError := true)
-      | .review body inlineComments =>
-        log s!"tool comment: posting review to {state.upstream}#{n} \
-          ({inlineComments.size} inline comments)"
-        try
-          let result ← GitHub.createPrReview state.pat state.upstream n body inlineComments
+        | .review body inlineComments =>
+          log s!"tool comment: posting review to {repo}#{n} \
+            ({inlineComments.size} inline comments)"
+          let result ← GitHub.createPrReview token repo n body inlineComments
           log "tool comment: ok"
           return toolContent result
-        catch e =>
-          log s!"tool comment: error: {e}"
-          return toolContent (toString e) (isError := true)
-      | .replyInline body cid =>
-        log s!"tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
-        try
-          let cidPr ← GitHub.getPrReviewCommentPrNumber state.pat state.upstream cid
+        | .replyInline body cid =>
+          log s!"tool comment: replying to inline comment {cid} on {repo}#{n}"
+          let cidPr ← GitHub.getPrReviewCommentPrNumber token repo cid
           if cidPr ≠ n then
             log s!"tool comment: comment {cid} belongs to PR #{cidPr}, not #{n}"
             return toolContent s!"comment {cid} does not belong to issue #{n}" (isError := true)
-          let result ← GitHub.replyToPrReviewComment state.pat state.upstream n cid body
+          let result ← GitHub.replyToPrReviewComment token repo n cid body
           log "tool comment: ok"
           return toolContent result
-        catch e =>
-          log s!"tool comment: error: {e}"
-          return toolContent (toString e) (isError := true)
-      | .newInline comment =>
-        log s!"tool comment: new inline comment on {state.upstream}#{n} \
-          {comment.path}:{comment.line} ({comment.side})"
-        try
-          let result ← GitHub.createPrReviewComment state.pat state.upstream n
+        | .newInline comment =>
+          log s!"tool comment: new inline comment on {repo}#{n} \
+            {comment.path}:{comment.line} ({comment.side})"
+          let result ← GitHub.createPrReviewComment token repo n
             comment.body comment.path comment.line comment.side
           log "tool comment: ok"
           return toolContent result
-        catch e =>
-          log s!"tool comment: error: {e}"
-          return toolContent (toString e) (isError := true)
+      catch e =>
+        log s!"tool comment: error: {e}"
+        return toolContent (toString e) (isError := true)
   | .getTaskInput =>
     log "tool get_task_input"
     match state.inputJson with

--- a/OrchestraTest/ServerParseTest.lean
+++ b/OrchestraTest/ServerParseTest.lean
@@ -141,8 +141,8 @@ def parseToolCall_getPrComments_nonInteger : Test := do
 def parseToolCall_comment_issue : Test := do
   let args := Json.mkObj [("body", .str "Hello!")]
   match parseToolCall "comment" args with
-  | .comment (.issue body) => TestM.assertEqual body "Hello!" (msg := "body")
-  | _ => TestM.fail "expected .comment (.issue ...)"
+  | .comment (.issue body) .upstream => TestM.assertEqual body "Hello!" (msg := "body")
+  | _ => TestM.fail "expected .comment (.issue ...) .upstream"
 
 @[test]
 def parseToolCall_comment_missingBody : Test := do
@@ -163,10 +163,10 @@ def parseToolCall_comment_emptyBody : Test := do
 def parseToolCall_comment_review : Test := do
   let args := Json.mkObj [("body", .str "LGTM"), ("review", .bool true)]
   match parseToolCall "comment" args with
-  | .comment (.review body inlineComments) =>
+  | .comment (.review body inlineComments) .upstream =>
     TestM.assertEqual body "LGTM"           (msg := "body")
     TestM.assertEqual inlineComments.size 0 (msg := "no inline comments")
-  | _ => TestM.fail "expected .comment (.review ...)"
+  | _ => TestM.fail "expected .comment (.review ...) .upstream"
 
 @[test]
 def parseToolCall_comment_reviewWithInline : Test := do
@@ -182,7 +182,7 @@ def parseToolCall_comment_reviewWithInline : Test := do
     ("inline_comments", .arr #[item])
   ]
   match parseToolCall "comment" args with
-  | .comment (.review body inlineComments) =>
+  | .comment (.review body inlineComments) .upstream =>
     TestM.assertEqual body "Review body"    (msg := "body")
     TestM.assertEqual inlineComments.size 1 (msg := "inline comment count")
     match inlineComments[0]? with
@@ -192,7 +192,7 @@ def parseToolCall_comment_reviewWithInline : Test := do
       TestM.assertEqual ic.line 10             (msg := "inline line")
       TestM.assertEqual ic.body "Fix this"     (msg := "inline body")
       TestM.assertEqual ic.side "LEFT"         (msg := "inline side")
-  | _ => TestM.fail "expected .comment (.review ...) with inline"
+  | _ => TestM.fail "expected .comment (.review ...) .upstream with inline"
 
 @[test]
 def parseToolCall_comment_reviewWithInline_defaultSide : Test := do
@@ -207,11 +207,11 @@ def parseToolCall_comment_reviewWithInline_defaultSide : Test := do
     ("inline_comments", .arr #[item])
   ]
   match parseToolCall "comment" args with
-  | .comment (.review _ inlineComments) =>
+  | .comment (.review _ inlineComments) .upstream =>
     match inlineComments[0]? with
     | none => TestM.fail "no inline comment"
     | some ic => TestM.assertEqual ic.side "RIGHT" (msg := "default side")
-  | _ => TestM.fail "expected .comment (.review ...)"
+  | _ => TestM.fail "expected .comment (.review ...) .upstream"
 
 @[test]
 def parseToolCall_comment_reviewMutualExclusion_replyId : Test := do
@@ -245,10 +245,10 @@ def parseToolCall_comment_replyInline : Test := do
     ("reply_to_comment_id", .num ⟨99, 0⟩)
   ]
   match parseToolCall "comment" args with
-  | .comment (.replyInline body cid) =>
+  | .comment (.replyInline body cid) .upstream =>
     TestM.assertEqual body "Got it" (msg := "body")
     TestM.assertEqual cid  99       (msg := "comment id")
-  | _ => TestM.fail "expected .comment (.replyInline ...)"
+  | _ => TestM.fail "expected .comment (.replyInline ...) .upstream"
 
 @[test]
 def parseToolCall_comment_replyInline_withPath : Test := do
@@ -272,12 +272,12 @@ def parseToolCall_comment_newInline : Test := do
     ("side", .str "LEFT")
   ]
   match parseToolCall "comment" args with
-  | .comment (.newInline ic) =>
+  | .comment (.newInline ic) .upstream =>
     TestM.assertEqual ic.body "Fix here" (msg := "body")
     TestM.assertEqual ic.path "Foo.lean" (msg := "path")
     TestM.assertEqual ic.line 42         (msg := "line")
     TestM.assertEqual ic.side "LEFT"     (msg := "side")
-  | _ => TestM.fail "expected .comment (.newInline ...)"
+  | _ => TestM.fail "expected .comment (.newInline ...) .upstream"
 
 @[test]
 def parseToolCall_comment_newInline_defaultSide : Test := do
@@ -287,9 +287,9 @@ def parseToolCall_comment_newInline_defaultSide : Test := do
     ("line", .num ⟨1, 0⟩)
   ]
   match parseToolCall "comment" args with
-  | .comment (.newInline ic) =>
+  | .comment (.newInline ic) .upstream =>
     TestM.assertEqual ic.side "RIGHT" (msg := "default side RIGHT")
-  | _ => TestM.fail "expected .comment (.newInline ...)"
+  | _ => TestM.fail "expected .comment (.newInline ...) .upstream"
 
 @[test]
 def parseToolCall_comment_pathWithoutLine : Test := do
@@ -304,6 +304,36 @@ def parseToolCall_comment_lineWithoutPath : Test := do
   match parseToolCall "comment" args with
   | .parseError _ => TestM.assert true
   | _ => TestM.fail "expected .parseError: line without path"
+
+-- parseToolCall: comment — target parameter
+
+@[test]
+def parseToolCall_comment_targetUpstreamExplicit : Test := do
+  let args := Json.mkObj [("body", .str "hi"), ("target", .str "upstream")]
+  match parseToolCall "comment" args with
+  | .comment (.issue _) .upstream => TestM.assert true
+  | _ => TestM.fail "expected .comment ... .upstream"
+
+@[test]
+def parseToolCall_comment_targetFork : Test := do
+  let args := Json.mkObj [("body", .str "hi"), ("target", .str "fork")]
+  match parseToolCall "comment" args with
+  | .comment (.issue _) .fork => TestM.assert true
+  | _ => TestM.fail "expected .comment ... .fork"
+
+@[test]
+def parseToolCall_comment_targetInvalid : Test := do
+  let args := Json.mkObj [("body", .str "hi"), ("target", .str "bad")]
+  match parseToolCall "comment" args with
+  | .parseError _ => TestM.assert true
+  | _ => TestM.fail "expected .parseError for invalid target"
+
+@[test]
+def parseToolCall_comment_targetFork_review : Test := do
+  let args := Json.mkObj [("body", .str "LGTM"), ("review", .bool true), ("target", .str "fork")]
+  match parseToolCall "comment" args with
+  | .comment (.review _ _) .fork => TestM.assert true
+  | _ => TestM.fail "expected .comment (.review ...) .fork"
 
 -- parseRequest
 


### PR DESCRIPTION
WIP: The issue id scope of a task is currently only one number. For this feature to be useful, the scope needs to be a (list of) pair of (upstream/fork, PR number) or even (repository, PR number).