### PR TITLE
feat: add monadic typeclass interfaces for IO abstraction

### DIFF
--- a/Orchestra.lean
+++ b/Orchestra.lean
@@ -1,3 +1,4 @@
+import Orchestra.Monad
 import Orchestra.AgentDef
 import Orchestra.ConcertManager
 import Orchestra.Agents.Claude

--- a/Orchestra/Monad.lean
+++ b/Orchestra/Monad.lean
@@ -1,0 +1,5 @@
+import Orchestra.Monad.Log
+import Orchestra.Monad.Config
+import Orchestra.Monad.TaskStore
+import Orchestra.Monad.Queue
+import Orchestra.Monad.GitHub

--- a/Orchestra/Monad/Config.lean
+++ b/Orchestra/Monad/Config.lean
@@ -1,0 +1,16 @@
+import Orchestra.Config
+
+namespace Orchestra
+
+/-- Abstract interface for reading configuration and prompt files. -/
+class MonadConfig (m : Type → Type) where
+  loadAppConfig     : Option System.FilePath → m AppConfig
+  loadSystemPrompt  : Option String → m (Option String)
+  loadPrependPrompt : Option String → m (Option String)
+
+instance : MonadConfig IO where
+  loadAppConfig     := fun path => Orchestra.loadAppConfig path
+  loadSystemPrompt  := fun name => Orchestra.loadSystemPrompt name
+  loadPrependPrompt := fun name => Orchestra.loadPrependPrompt name
+
+end Orchestra

--- a/Orchestra/Monad/GitHub.lean
+++ b/Orchestra/Monad/GitHub.lean
@@ -1,0 +1,52 @@
+import Lean.Data.Json
+import Orchestra.Config
+import Orchestra.GitHub
+
+open Lean (Json)
+
+namespace Orchestra
+
+open GitHub (InlineComment)
+
+/--
+Abstract interface for GitHub App-level authentication operations.
+Used when the agent acts as a GitHub App (JWT-based flow).
+-/
+class MonadGitHubApp (m : Type → Type) where
+  createJWT               : Nat → String → m String
+  getInstallationId       : String → String → m Nat
+  createInstallationToken : String → Nat → m String
+  setupGhAuth             : String → m Unit
+
+/--
+Abstract interface for GitHub API operations using a PAT or pre-authenticated token.
+Covers pull requests, issue comments, and PR review threads.
+-/
+class MonadGitHub (m : Type → Type) where
+  createPullRequest          : String → Repository → String → String → String → String → m String
+  createPullRequestOnRepo    : String → Repository → String → String → String → String → m String
+  getPrReviewThreads         : Repository → Nat → String → m Json
+  createIssueComment         : String → Repository → Nat → String → m String
+  replyToPrReviewComment     : String → Repository → Nat → Nat → String → m String
+  createPrReviewComment      : String → Repository → Nat → String → String → Nat → String → m String
+  createPrReview             : String → Repository → Nat → String → Array InlineComment → m String
+  getPrReviewCommentPrNumber : String → Repository → Nat → m Nat
+
+instance : MonadGitHubApp IO where
+  createJWT               := Orchestra.GitHub.createJWT
+  getInstallationId       := Orchestra.GitHub.getInstallationId
+  createInstallationToken := Orchestra.GitHub.createInstallationToken
+  setupGhAuth             := Orchestra.GitHub.setupGhAuth
+
+instance : MonadGitHub IO where
+  createPullRequest          := Orchestra.GitHub.createPullRequest
+  createPullRequestOnRepo    := Orchestra.GitHub.createPullRequestOnRepo
+  getPrReviewThreads         := Orchestra.GitHub.getPrReviewThreads
+  createIssueComment         := Orchestra.GitHub.createIssueComment
+  replyToPrReviewComment     := Orchestra.GitHub.replyToPrReviewComment
+  createPrReviewComment      := Orchestra.GitHub.createPrReviewComment
+  createPrReview             := fun pat upstream prNumber body comments =>
+                                  Orchestra.GitHub.createPrReview pat upstream prNumber body comments
+  getPrReviewCommentPrNumber := Orchestra.GitHub.getPrReviewCommentPrNumber
+
+end Orchestra

--- a/Orchestra/Monad/Log.lean
+++ b/Orchestra/Monad/Log.lean
@@ -1,0 +1,12 @@
+namespace Orchestra
+
+/-- Abstract interface for logging. -/
+class MonadLog (m : Type → Type) where
+  logInfo  : String → m Unit
+  logError : String → m Unit
+
+instance : MonadLog IO where
+  logInfo  := IO.println
+  logError := IO.eprintln
+
+end Orchestra

--- a/Orchestra/Monad/Queue.lean
+++ b/Orchestra/Monad/Queue.lean
@@ -1,0 +1,35 @@
+import Orchestra.Queue
+
+namespace Orchestra
+
+open Queue (QueueEntry ConcertRun)
+
+/--
+Abstract interface for persisting and retrieving queue entries, concert runs,
+and the daemon PID file.
+-/
+class MonadQueueStore (m : Type → Type) where
+  saveEntry          : QueueEntry → m Unit
+  loadEntry          : String → m (Option QueueEntry)
+  loadAllEntries     : m (Array QueueEntry)
+  saveConcertRun     : ConcertRun → m Unit
+  loadConcertRun     : String → m (Option ConcertRun)
+  loadAllConcertRuns : m (Array ConcertRun)
+  writePid           : UInt32 → m Unit
+  readPid            : m (Option UInt32)
+  deletePid          : m Unit
+  daemonRunning      : m Bool
+
+instance : MonadQueueStore IO where
+  saveEntry          := Orchestra.Queue.saveEntry
+  loadEntry          := Orchestra.Queue.loadEntry
+  loadAllEntries     := Orchestra.Queue.loadAllEntries
+  saveConcertRun     := Orchestra.Queue.saveConcertRun
+  loadConcertRun     := Orchestra.Queue.loadConcertRun
+  loadAllConcertRuns := Orchestra.Queue.loadAllConcertRuns
+  writePid           := Orchestra.Queue.writePid
+  readPid            := Orchestra.Queue.readPid
+  deletePid          := Orchestra.Queue.deletePid
+  daemonRunning      := Orchestra.Queue.daemonRunning
+
+end Orchestra

--- a/Orchestra/Monad/TaskStore.lean
+++ b/Orchestra/Monad/TaskStore.lean
@@ -1,0 +1,29 @@
+import Orchestra.TaskStore
+
+namespace Orchestra
+
+open TaskStore (TaskRecord)
+
+/--
+Abstract interface for persisting and retrieving task records and series pointers.
+Also provides ID generation and timestamp utilities needed when creating records.
+-/
+class MonadTaskStore (m : Type → Type) where
+  saveTask            : TaskRecord → m Unit
+  loadTask            : String → m (Option TaskRecord)
+  loadAllTasks        : m (Array TaskRecord)
+  latestInSeries      : String → m (Option String)
+  updateSeriesPointer : String → String → m Unit
+  generateId          : m String
+  currentIso8601      : m String
+
+instance : MonadTaskStore IO where
+  saveTask            := Orchestra.TaskStore.saveTask
+  loadTask            := Orchestra.TaskStore.loadTask
+  loadAllTasks        := Orchestra.TaskStore.loadAllTasks
+  latestInSeries      := Orchestra.TaskStore.latestInSeries
+  updateSeriesPointer := Orchestra.TaskStore.updateSeriesPointer
+  generateId          := Orchestra.TaskStore.generateId
+  currentIso8601      := Orchestra.TaskStore.currentIso8601
+
+end Orchestra


### PR DESCRIPTION
## Summary

Implements #88 — introduces `Orchestra.Monad` with five typeclass interfaces that abstract over the `IO` operations used throughout orchestra:

- **`MonadLog`** — `logInfo` / `logError` (replaces ad-hoc `IO.println` / `IO.eprintln`)
- **`MonadConfig`** — `loadAppConfig` / `loadSystemPrompt` / `loadPrependPrompt`
- **`MonadTaskStore`** — task record persistence, series pointers, ID generation, timestamps
- **`MonadQueueStore`** — queue entries, concert runs, daemon PID file management
- **`MonadGitHub`** / **`MonadGitHubApp`** — PAT-based API operations and GitHub App auth flow (JWT, installation tokens, `gh` auth setup)

All interfaces have `IO` instances that delegate to the existing implementations, so no existing call sites are changed and behaviour is preserved. The interfaces are re-exported from `Orchestra.Monad` and imported via `Orchestra.lean`.

## Test plan

- [x] `lake build Orchestra.Monad` succeeds with all 12 jobs passing
- [x] `lake build` (full project, 496 jobs) succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)