### PR TITLE
feat: add typeclass-based monadic interfaces

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -111,7 +111,7 @@ private def mcpServerHandler (p : Parsed) : IO UInt32 := do
     | none => GitHub.getInstallationId jwt fork.owner
   let token ← GitHub.createInstallationToken jwt installationId
   GitHub.setupGhAuth token
-  let serverState : Server.State := {
+  let serverState : Server.State IO := {
     upstream, fork
     allowedTools := if allowPR then ["create_pr"] else []
     appId := appConfig.appId
@@ -1202,7 +1202,7 @@ private def interactiveHandler (p : Parsed) : IO UInt32 := do
   let repoPath ← Repo.ensureCloned fork upstream
   IO.println s!"  Repo at {repoPath}"
   let backendName := backend.getD "claude"
-  let serverState : Server.State := {
+  let serverState : Server.State IO := {
     upstream, fork
     allowedTools
     appId          := appConfig.appId

--- a/Main.lean
+++ b/Main.lean
@@ -99,31 +99,6 @@ private def runHandler (p : Parsed) : IO UInt32 := do
 
   return (0 : UInt32)
 
-private def mcpServerHandler (p : Parsed) : IO UInt32 := do
-  let upstream ← IO.ofExcept (Repository.parse (p.positionalArg! "upstream" |>.as! String))
-  let fork ← IO.ofExcept (Repository.parse (p.positionalArg! "fork" |>.as! String))
-  let allowPR := p.hasFlag "allow_pr"
-  let configPath := p.flag? "config" |>.map (·.as! String)
-  let appConfig ← loadAppConfig (configPath.map System.FilePath.mk)
-  let jwt ← GitHub.createJWT appConfig.appId appConfig.privateKeyPath
-  let installationId ← match appConfig.installationId with
-    | some id => pure id
-    | none => GitHub.getInstallationId jwt fork.owner
-  let token ← GitHub.createInstallationToken jwt installationId
-  GitHub.setupGhAuth token
-  let serverState : Server.State IO := {
-    upstream, fork
-    allowedTools := if allowPR then ["create_pr"] else []
-    appId := appConfig.appId
-    privateKeyPath := appConfig.privateKeyPath
-    installationId
-    pat := appConfig.pat
-  }
-  let (port, _shutdown) ← Server.start serverState
-  IO.println s!"MCP server listening on port {port}"
-  repeat do
-    IO.sleep 60000
-  return (0 : UInt32)
 
 private def prepareHandler (p : Parsed) : IO UInt32 := do
   let upstream ← IO.ofExcept (Repository.parse (p.positionalArg! "upstream" |>.as! String))
@@ -943,19 +918,6 @@ private def runCmd' : Cmd := `[Cli|
     "task-file" : String; "Path to the JSON task file"
 ]
 
-private def mcpServerCmd : Cmd := `[Cli|
-  mcp VIA mcpServerHandler; ["0.1.0"]
-  "Start the MCP server and print the port it is listening on."
-
-  FLAGS:
-    c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
-    allow_pr; "Allow the create_pr tool (disabled by default)"
-
-  ARGS:
-    "upstream" : String; "Upstream repository in 'owner/repo' format"
-    "fork" : String; "Fork repository in 'owner/repo' format"
-]
-
 private def prepareCmd : Cmd := `[Cli|
   prepare VIA prepareHandler; ["0.1.0"]
   "Clone the fork and configure the upstream remote."
@@ -1183,54 +1145,23 @@ private def interactiveHandler (p : Parsed) : IO UInt32 := do
   let toolsStr    := p.flag? "tools"    |>.map (·.as! String)
   let backend     := p.flag? "backend"  |>.map (·.as! String)
   let model       := p.flag? "model"    |>.map (·.as! String)
-  let budget      := p.flag? "budget"   |>.bind (fun v => parseFloat? (v.as! String)) |>.getD 4.0
+  let budget      := p.flag? "budget"   |>.bind (fun v => parseFloat? (v.as! String))
   let debug       := p.hasFlag "debug"
   let configPath  := p.flag? "config"   |>.map (·.as! String)
   let upstream ← IO.ofExcept (Repository.parse upstreamStr)
   let fork     ← IO.ofExcept (Repository.parse forkStr)
-  let allowedTools : List String := match toolsStr with
-    | none | some "all" => allOptionalTools
-    | some s => s.splitOn ","
+  let tools : Option (List String) := toolsStr.map fun s =>
+    if s == "all" then allOptionalTools else s.splitOn ","
   let appConfig ← loadAppConfig (configPath.map System.FilePath.mk)
-  let jwt ← GitHub.createJWT appConfig.appId appConfig.privateKeyPath
-  let installationId ← match appConfig.installationId with
-    | some id => pure id
-    | none    => GitHub.getInstallationId jwt fork.owner
-  let token ← GitHub.createInstallationToken jwt installationId
-  GitHub.setupGhAuth token
-  IO.println s!"Cloning/updating {fork}..."
-  let repoPath ← Repo.ensureCloned fork upstream
-  IO.println s!"  Repo at {repoPath}"
-  let backendName := backend.getD "claude"
-  let serverState : Server.State IO := {
+  let ioTask : IOTask .unit .unit := {
     upstream, fork
-    allowedTools
-    appId          := appConfig.appId
-    privateKeyPath := appConfig.privateKeyPath
-    installationId
-    pat            := appConfig.pat
-    agentBackend   := backendName
+    mode    := .fork
+    prompt  := ""
+    backend, model, budget, tools
   }
-  let (port, shutdown) ← Server.start serverState
-  IO.println s!"  MCP server on port {port}"
-  let agentDef := match backend with
-    | some "pi"       => AgentDef.pi
-    | some "vibe"     => AgentDef.vibe
-    | some "opencode" => AgentDef.opencode
-    | _               => AgentDef.claude
-  let extraPorts := appConfig.agentAuthConfigs.find? (fun c => c.name == backendName)
-    |>.map (·.extraPorts) |>.getD #[]
-  let apiKeyEnv ← TaskRunner.resolveAuthEnv appConfig agentDef backendName none
-  IO.println "  Launching agent..."
-  let result ← Sandbox.launchAgent agentDef repoPath "" port token
-    (debug := debug) (pluginDirs := appConfig.pluginDirs)
-    (model := model) (budget := budget)
-    (extraEnv := apiKeyEnv) (extraPorts := extraPorts)
-    (additionalPaths := appConfig.additionalSandboxPaths)
+  let (_, _, _) ← TaskRunner.runIOTask appConfig ioTask 0 debug default
     (interactiveAgent := true)
-  IO.println s!"  Agent exited with code {result.exitCode}"
-  shutdown
-  return if result.exitCode == 0 then 0 else 1
+  return 0
 
 private def interactiveCmd : Cmd := `[Cli|
   interactive VIA interactiveHandler; ["0.1.0"]
@@ -1258,7 +1189,6 @@ def orchestraCmd : Cmd := `[Cli|
   SUBCOMMANDS:
     runCmd';
     interactiveCmd;
-    mcpServerCmd;
     prepareCmd;
     cleanupCmd;
     tasksCmd;

--- a/Orchestra.lean
+++ b/Orchestra.lean
@@ -1,5 +1,6 @@
 import Orchestra.Dirs
 import Orchestra.Migrate
+import Orchestra.Monad
 import Orchestra.AgentDef
 import Orchestra.ConcertManager
 import Orchestra.Agents.Claude

--- a/Orchestra/Concert/Evaluation.lean
+++ b/Orchestra/Concert/Evaluation.lean
@@ -3,7 +3,6 @@ import Orchestra.ConcertManager
 import Orchestra.Monad
 import Orchestra.Queue
 import Orchestra.TaskRunner
-import Orchestra.TaskStore
 import Std.Sync
 
 open Lean (Json)

--- a/Orchestra/Concert/Evaluation.lean
+++ b/Orchestra/Concert/Evaluation.lean
@@ -1,11 +1,13 @@
 import Orchestra.Concert.Basic
 import Orchestra.ConcertManager
+import Orchestra.Monad
 import Orchestra.Queue
 import Orchestra.TaskRunner
 import Orchestra.TaskStore
 import Std.Sync
 
 open Lean (Json)
+open Orchestra (generateTaskId currentIso8601 saveEntry readAppConfig)
 
 namespace Orchestra.Concert
 
@@ -53,9 +55,9 @@ mutual
     | .abort   => throw (IO.userError "Concert aborted")
     | .op (.run o t input) k => do
         let spec       := t.toIOTask input
-        let stepKey    ← TaskStore.generateId
+        let stepKey    ← generateTaskId
         let promise    ← ConcertManager.register mgr stepKey
-        let createdAt  ← TaskStore.currentIso8601
+        let createdAt  ← currentIso8601
         let entry : Queue.QueueEntry := {
           id            := stepKey
           createdAt
@@ -81,7 +83,7 @@ mutual
           outputType    := o
           inputJson     := none
         }
-        Queue.saveEntry entry
+        saveEntry entry
         -- Block until the queue worker signals completion (always resolved, safe to use result!)
         let resultJson ← IO.wait promise.result!
         let result :=
@@ -95,7 +97,7 @@ mutual
 end
 
 def evalWithConfig (c : Concert α) : IO α := do
-  let appConfig ← loadAppConfig
+  let appConfig ← readAppConfig none
   eval appConfig false none c
 
 end Orchestra.Concert

--- a/Orchestra/Dirs.lean
+++ b/Orchestra/Dirs.lean
@@ -38,8 +38,16 @@ def configBase : IO System.FilePath := do
     return legacy
   return xdgDir
 
+private initialize dataDirOverride : IO.Ref (Option System.FilePath) ← IO.mkRef none
+
+/-- Override the data base directory (for testing). -/
+def setDataDirOverride (p : Option System.FilePath) : IO Unit :=
+  dataDirOverride.set p
+
 /-- Data base: always uses the XDG data dir, no legacy fallback. -/
-def dataBase : IO System.FilePath :=
-  orchestraDataDir
+def dataBase : IO System.FilePath := do
+  match ← dataDirOverride.get with
+  | some p => return p
+  | none   => orchestraDataDir
 
 end Orchestra.Dirs

--- a/Orchestra/Monad.lean
+++ b/Orchestra/Monad.lean
@@ -3,6 +3,7 @@ import Orchestra.Monad.Config
 import Orchestra.Monad.GitHub
 import Orchestra.Monad.TaskStore
 import Orchestra.Monad.Queue
+import Orchestra.Monad.ProjectTool
 
 /-!
 # Orchestra Monadic Interfaces
@@ -12,14 +13,15 @@ main effect categories.  Each typeclass abstracts over a concrete IO operation,
 enabling alternative instances (e.g. test monads) that do not perform real
 side effects.
 
-| Typeclass        | Abstracts                                        |
-|------------------|--------------------------------------------------|
-| `MonadLog`       | stdout / stderr logging                          |
-| `MonadConfig`    | reading application and prompt configuration     |
-| `MonadGitHubApp` | GitHub App authentication (JWT, install tokens)  |
-| `MonadGitHub`    | GitHub API operations via PAT / install token    |
-| `MonadTaskStore` | task-record persistence and series pointers      |
-| `MonadQueue`     | queue-entry persistence and PID-file management  |
+| Typeclass          | Abstracts                                        |
+|--------------------|--------------------------------------------------|
+| `MonadLog`         | stdout / stderr logging                          |
+| `MonadConfig`      | reading application and prompt configuration     |
+| `MonadGitHubApp`   | GitHub App authentication (JWT, install tokens)  |
+| `MonadGitHub`      | GitHub API operations via PAT / install token    |
+| `MonadTaskStore`   | task-record persistence and series pointers      |
+| `MonadQueue`       | queue-entry persistence and PID-file management  |
+| `MonadProjectTool` | MCP project-tool evaluation                      |
 
 Every typeclass ships with an `IO` instance that delegates to the existing
 concrete implementations, preserving all prior behaviour.

--- a/Orchestra/Monad.lean
+++ b/Orchestra/Monad.lean
@@ -1,0 +1,26 @@
+import Orchestra.Monad.Log
+import Orchestra.Monad.Config
+import Orchestra.Monad.GitHub
+import Orchestra.Monad.TaskStore
+import Orchestra.Monad.Queue
+
+/-!
+# Orchestra Monadic Interfaces
+
+This module collects the typeclass-based monadic interfaces for Orchestra's
+main effect categories.  Each typeclass abstracts over a concrete IO operation,
+enabling alternative instances (e.g. test monads) that do not perform real
+side effects.
+
+| Typeclass        | Abstracts                                        |
+|------------------|--------------------------------------------------|
+| `MonadLog`       | stdout / stderr logging                          |
+| `MonadConfig`    | reading application and prompt configuration     |
+| `MonadGitHubApp` | GitHub App authentication (JWT, install tokens)  |
+| `MonadGitHub`    | GitHub API operations via PAT / install token    |
+| `MonadTaskStore` | task-record persistence and series pointers      |
+| `MonadQueue`     | queue-entry persistence and PID-file management  |
+
+Every typeclass ships with an `IO` instance that delegates to the existing
+concrete implementations, preserving all prior behaviour.
+-/

--- a/Orchestra/Monad.lean
+++ b/Orchestra/Monad.lean
@@ -5,6 +5,8 @@ import Orchestra.Monad.TaskStore
 import Orchestra.Monad.Queue
 import Orchestra.Monad.ProjectTool
 import Orchestra.Monad.SubmitOutput
+import Orchestra.Monad.Project
+import Orchestra.Monad.Claim
 
 /-!
 # Orchestra Monadic Interfaces
@@ -24,6 +26,8 @@ side effects.
 | `MonadQueue`        | queue-entry persistence and PID-file management  |
 | `MonadProjectTool`  | MCP project-tool evaluation                      |
 | `MonadSubmitOutput` | recording the agent's task output value          |
+| `MonadProject`      | project and issue record persistence             |
+| `MonadClaim`        | issue claim lock acquire / release               |
 
 Every typeclass ships with an `IO` instance that delegates to the existing
 concrete implementations, preserving all prior behaviour.

--- a/Orchestra/Monad.lean
+++ b/Orchestra/Monad.lean
@@ -4,6 +4,7 @@ import Orchestra.Monad.GitHub
 import Orchestra.Monad.TaskStore
 import Orchestra.Monad.Queue
 import Orchestra.Monad.ProjectTool
+import Orchestra.Monad.SubmitOutput
 
 /-!
 # Orchestra Monadic Interfaces
@@ -15,13 +16,14 @@ side effects.
 
 | Typeclass          | Abstracts                                        |
 |--------------------|--------------------------------------------------|
-| `MonadLog`         | stdout / stderr logging                          |
-| `MonadConfig`      | reading application and prompt configuration     |
-| `MonadGitHubApp`   | GitHub App authentication (JWT, install tokens)  |
-| `MonadGitHub`      | GitHub API operations via PAT / install token    |
-| `MonadTaskStore`   | task-record persistence and series pointers      |
-| `MonadQueue`       | queue-entry persistence and PID-file management  |
-| `MonadProjectTool` | MCP project-tool evaluation                      |
+| `MonadLog`          | stdout / stderr logging                          |
+| `MonadConfig`       | reading application and prompt configuration     |
+| `MonadGitHubApp`    | GitHub App authentication (JWT, install tokens)  |
+| `MonadGitHub`       | GitHub API operations via PAT / install token    |
+| `MonadTaskStore`    | task-record persistence and series pointers      |
+| `MonadQueue`        | queue-entry persistence and PID-file management  |
+| `MonadProjectTool`  | MCP project-tool evaluation                      |
+| `MonadSubmitOutput` | recording the agent's task output value          |
 
 Every typeclass ships with an `IO` instance that delegates to the existing
 concrete implementations, preserving all prior behaviour.

--- a/Orchestra/Monad/Claim.lean
+++ b/Orchestra/Monad/Claim.lean
@@ -1,0 +1,25 @@
+import Orchestra.Project.Claim
+
+namespace Orchestra
+
+/-- Typeclass for monads that can read and write issue claim records. -/
+class MonadClaim (m : Type → Type) where
+  loadClaim         : Project.ProjectId → Project.IssueId → m (Option Project.Claim)
+  loadClaims        : Project.ProjectId → m (Array (Project.IssueId × Project.Claim))
+  tryClaim          : Project.ClaimManager → Project.ProjectId → Project.IssueId
+                      → String → String → String → Option String → m Project.ClaimResult
+  release           : Project.ClaimManager → Project.ProjectId → Project.IssueId
+                      → Project.IssueStatus → String → m Bool
+  updateClaimTaskId : Project.ClaimManager → Project.ProjectId → Project.IssueId
+                      → String → m Unit
+  forceRelease      : Project.ClaimManager → Project.ProjectId → Project.IssueId → m Bool
+
+instance : MonadClaim IO where
+  loadClaim         pid iid                   := Project.loadClaim pid iid
+  loadClaims        pid                       := Project.loadClaims pid
+  tryClaim          mgr pid iid tid ag now ser := Project.tryClaim mgr pid iid tid ag now ser
+  release           mgr pid iid st now        := Project.release mgr pid iid st now
+  updateClaimTaskId mgr pid iid tid           := Project.updateClaimTaskId mgr pid iid tid
+  forceRelease      mgr pid iid               := Project.forceRelease mgr pid iid
+
+end Orchestra

--- a/Orchestra/Monad/Config.lean
+++ b/Orchestra/Monad/Config.lean
@@ -1,0 +1,21 @@
+import Orchestra.Config
+
+namespace Orchestra
+
+/-- Typeclass for monads that can read orchestra configuration. -/
+class MonadConfig (m : Type → Type) where
+  /-- Read the application config from the given path, or `~/.agent/config.json` if none. -/
+  readAppConfig     : Option System.FilePath → m AppConfig
+  /-- Read a named system prompt from `~/.agent/prompts/<name>.md`. -/
+  readSystemPrompt  : Option String → m (Option String)
+  /-- Read a named prepend prompt from `~/.agent/prompts/<name>.md`. -/
+  readPrependPrompt : Option String → m (Option String)
+
+export MonadConfig (readAppConfig readSystemPrompt readPrependPrompt)
+
+instance : MonadConfig IO where
+  readAppConfig path    := loadAppConfig path
+  readSystemPrompt name  := loadSystemPrompt name
+  readPrependPrompt name := loadPrependPrompt name
+
+end Orchestra

--- a/Orchestra/Monad/GitHub.lean
+++ b/Orchestra/Monad/GitHub.lean
@@ -1,0 +1,65 @@
+import Lean.Data.Json
+import Orchestra.Config
+import Orchestra.GitHub
+
+open Lean (Json)
+
+namespace Orchestra
+
+/-- Typeclass for monads that can perform GitHub App authentication operations.
+    This covers operations requiring the GitHub App private key (JWT creation,
+    installation token generation). -/
+class MonadGitHubApp (m : Type → Type) where
+  /-- Create a GitHub App JWT from an app ID and private key path. -/
+  createJWT : Nat → String → m String
+  /-- Resolve the installation ID for a given owner using a JWT. -/
+  getInstallationId : String → String → m Nat
+  /-- Create a short-lived installation access token. -/
+  createInstallationToken : String → Nat → m String
+  /-- Configure the `gh` CLI to use the given token. -/
+  setupGhAuth : String → m Unit
+
+export MonadGitHubApp (createJWT getInstallationId createInstallationToken setupGhAuth)
+
+instance : MonadGitHubApp IO where
+  createJWT               := GitHub.createJWT
+  getInstallationId       := GitHub.getInstallationId
+  createInstallationToken := GitHub.createInstallationToken
+  setupGhAuth             := GitHub.setupGhAuth
+
+/-- Typeclass for monads that can interact with the GitHub API using a PAT or
+    installation token.  Differentiated from `MonadGitHubApp` because many
+    operations only need a token, not the private key. -/
+class MonadGitHub (m : Type → Type) where
+  /-- Create a pull request on the upstream repo using a PAT. -/
+  createPullRequest : String → Repository → String → String → String → String → m String
+  /-- Create a pull request within a single repository using a token. -/
+  createPullRequestOnRepo : String → Repository → String → String → String → String → m String
+  /-- Fetch review threads for a pull request via GraphQL. -/
+  getPrReviewThreads : Repository → Nat → String → m Json
+  /-- Post a comment on an issue or pull request. -/
+  createIssueComment : String → Repository → Nat → String → m String
+  /-- Reply to an inline PR review comment. -/
+  replyToPrReviewComment : String → Repository → Nat → Nat → String → m String
+  /-- Create a new inline PR review comment on a specific file and line. -/
+  createPrReviewComment : String → Repository → Nat → String → String → Nat → String → m String
+  /-- Post a review (with optional inline comments) on a pull request. -/
+  createPrReview : String → Repository → Nat → String → Array GitHub.InlineComment → m String
+  /-- Return the pull-request number that a review comment belongs to. -/
+  getPrReviewCommentPrNumber : String → Repository → Nat → m Nat
+
+export MonadGitHub (createPullRequest createPullRequestOnRepo getPrReviewThreads
+  createIssueComment replyToPrReviewComment createPrReviewComment createPrReview
+  getPrReviewCommentPrNumber)
+
+instance : MonadGitHub IO where
+  createPullRequest          := GitHub.createPullRequest
+  createPullRequestOnRepo    := GitHub.createPullRequestOnRepo
+  getPrReviewThreads         := GitHub.getPrReviewThreads
+  createIssueComment         := GitHub.createIssueComment
+  replyToPrReviewComment     := GitHub.replyToPrReviewComment
+  createPrReviewComment      := GitHub.createPrReviewComment
+  createPrReview pat repo n body comments := GitHub.createPrReview pat repo n body comments
+  getPrReviewCommentPrNumber := GitHub.getPrReviewCommentPrNumber
+
+end Orchestra

--- a/Orchestra/Monad/Log.lean
+++ b/Orchestra/Monad/Log.lean
@@ -1,0 +1,19 @@
+namespace Orchestra
+
+/-- Typeclass for monads that support structured logging. -/
+class MonadLog (m : Type → Type) where
+  /-- Log an informational message (stdout). -/
+  logInfo  : String → m Unit
+  /-- Log an error message (stderr). -/
+  logError : String → m Unit
+
+export MonadLog (logInfo logError)
+
+instance : MonadLog IO where
+  logInfo  := IO.println
+  logError msg := do
+    let stderr ← IO.getStderr
+    stderr.putStrLn msg
+    stderr.flush
+
+end Orchestra

--- a/Orchestra/Monad/Project.lean
+++ b/Orchestra/Monad/Project.lean
@@ -1,0 +1,43 @@
+import Orchestra.Project.Basic
+import Orchestra.Project.Role
+
+namespace Orchestra
+
+/-- Typeclass for monads that can read and write project and issue records,
+    and load role definitions. -/
+class MonadProject (m : Type → Type) where
+  freshProjectId  : m Project.ProjectId
+  freshIssueId    : m Project.IssueId
+  saveProject     : Project.Project → m Unit
+  loadProject     : Project.ProjectId → m (Option Project.Project)
+  loadAllProjects : m (Array Project.Project)
+  saveIssue       : Project.Issue → m Unit
+  loadIssue       : Project.ProjectId → Project.IssueId → m (Option Project.Issue)
+  loadIssues      : Project.ProjectId → m (Array Project.Issue)
+  /-- Find an issue by ID across all projects, returning the owning project too. -/
+  findIssue       : Project.IssueId → m (Option (Project.Project × Project.Issue))
+  /-- Direct children of `parent` within `pid`. -/
+  childrenOf      : Project.ProjectId → Project.IssueId → m (Array Project.Issue)
+  /-- Top-level (parentless) issues of `pid`. -/
+  rootIssues      : Project.ProjectId → m (Array Project.Issue)
+  loadRole        : Project.ProjectId → String → m (Option Project.Role)
+  loadAllRoles    : Project.ProjectId → m (Array Project.Role)
+  roleSearchPaths : Project.ProjectId → String → m (System.FilePath × System.FilePath)
+
+instance : MonadProject IO where
+  freshProjectId  := Project.freshProjectId
+  freshIssueId    := Project.freshIssueId
+  saveProject     := Project.saveProject
+  loadProject     := Project.loadProject
+  loadAllProjects := Project.loadAllProjects
+  saveIssue       := Project.saveIssue
+  loadIssue       := Project.loadIssue
+  loadIssues      := Project.loadIssues
+  findIssue       := Project.findIssue
+  childrenOf      := Project.childrenOf
+  rootIssues      := Project.rootIssues
+  loadRole        := Project.loadRole
+  loadAllRoles    := Project.loadAllRoles
+  roleSearchPaths := Project.roleSearchPaths
+
+end Orchestra

--- a/Orchestra/Monad/ProjectTool.lean
+++ b/Orchestra/Monad/ProjectTool.lean
@@ -1,0 +1,21 @@
+import Lean.Data.Json
+import Orchestra.Project.Tools
+
+open Lean (Json)
+
+namespace Orchestra
+
+/-- Typeclass for monads that can evaluate MCP project tools.
+    Abstracts the concrete `IO`-based `Project.Tools.evalProjectTool` so that
+    alternative instances (e.g. test monads) can be provided without real
+    side effects. -/
+class MonadProjectTool (m : Type → Type) where
+  /-- Evaluate a project tool call in the given environment. -/
+  evalProjectTool : Project.Tools.Env → Project.Tools.ProjectTool → m Json
+
+export MonadProjectTool (evalProjectTool)
+
+instance : MonadProjectTool IO where
+  evalProjectTool := Project.Tools.evalProjectTool
+
+end Orchestra

--- a/Orchestra/Monad/ProjectTool.lean
+++ b/Orchestra/Monad/ProjectTool.lean
@@ -13,8 +13,6 @@ class MonadProjectTool (m : Type → Type) where
   /-- Evaluate a project tool call in the given environment. -/
   evalProjectTool : Project.Tools.Env → Project.Tools.ProjectTool → m Json
 
-export MonadProjectTool (evalProjectTool)
-
 instance : MonadProjectTool IO where
   evalProjectTool := Project.Tools.evalProjectTool
 

--- a/Orchestra/Monad/Queue.lean
+++ b/Orchestra/Monad/Queue.lean
@@ -1,0 +1,34 @@
+import Orchestra.Queue
+
+namespace Orchestra
+
+/-- Typeclass for monads that can read and write queue entries.
+    Covers task-queue persistence, PID-file management, and entry status updates. -/
+class MonadQueue (m : Type → Type) where
+  /-- Persist a queue entry to disk. -/
+  saveEntry : Queue.QueueEntry → m Unit
+  /-- Load a queue entry by ID, returning `none` if it does not exist. -/
+  loadEntry : String → m (Option Queue.QueueEntry)
+  /-- Load all queue entries, newest first. -/
+  loadAllEntries : m (Array Queue.QueueEntry)
+  /-- Return the next pending entry to run, ordered by priority then age. -/
+  nextPending : m (Option Queue.QueueEntry)
+  /-- Write the daemon PID file. -/
+  writePid : UInt32 → m Unit
+  /-- Read the daemon PID file, returning `none` if absent. -/
+  readPid : m (Option UInt32)
+  /-- Delete the daemon PID file. -/
+  deletePid : m Unit
+
+export MonadQueue (saveEntry loadEntry loadAllEntries nextPending writePid readPid deletePid)
+
+instance : MonadQueue IO where
+  saveEntry      := Queue.saveEntry
+  loadEntry      := Queue.loadEntry
+  loadAllEntries := Queue.loadAllEntries
+  nextPending    := Queue.nextPending
+  writePid       := Queue.writePid
+  readPid        := Queue.readPid
+  deletePid      := Queue.deletePid
+
+end Orchestra

--- a/Orchestra/Monad/SubmitOutput.lean
+++ b/Orchestra/Monad/SubmitOutput.lean
@@ -1,0 +1,15 @@
+import Lean.Data.Json
+
+open Lean (Json)
+
+namespace Orchestra
+
+/-- Typeclass for monads that can record the agent's task output.
+    Only meaningful when the current task has a non-unit output type;
+    the `submit_task_output` MCP tool is only exposed in that case. -/
+class MonadSubmitOutput (m : Type → Type) where
+  submitOutput : Json → m Unit
+
+export MonadSubmitOutput (submitOutput)
+
+end Orchestra

--- a/Orchestra/Monad/TaskStore.lean
+++ b/Orchestra/Monad/TaskStore.lean
@@ -1,0 +1,35 @@
+import Orchestra.TaskStore
+
+namespace Orchestra
+
+/-- Typeclass for monads that can read and write task records.
+    Covers both individual task persistence and series-pointer tracking. -/
+class MonadTaskStore (m : Type → Type) where
+  /-- Persist a task record to disk. -/
+  saveTask : TaskStore.TaskRecord → m Unit
+  /-- Load a task record by ID, returning `none` if it does not exist. -/
+  loadTask : String → m (Option TaskStore.TaskRecord)
+  /-- Load all task records, newest first. -/
+  loadAllTasks : m (Array TaskStore.TaskRecord)
+  /-- Return the latest task ID in a named series, or `none` if none exists. -/
+  latestInSeries : String → m (Option String)
+  /-- Update the series pointer to point to `taskId`. -/
+  updateSeriesPointer : String → String → m Unit
+  /-- Generate a fresh unique task ID. -/
+  generateTaskId : m String
+  /-- Return the current time as an ISO-8601 string. -/
+  currentIso8601 : m String
+
+export MonadTaskStore (saveTask loadTask loadAllTasks latestInSeries
+  updateSeriesPointer generateTaskId currentIso8601)
+
+instance : MonadTaskStore IO where
+  saveTask            := TaskStore.saveTask
+  loadTask            := TaskStore.loadTask
+  loadAllTasks        := TaskStore.loadAllTasks
+  latestInSeries      := TaskStore.latestInSeries
+  updateSeriesPointer := TaskStore.updateSeriesPointer
+  generateTaskId      := TaskStore.generateId
+  currentIso8601      := TaskStore.currentIso8601
+
+end Orchestra

--- a/Orchestra/Project/Enqueue.lean
+++ b/Orchestra/Project/Enqueue.lean
@@ -1,0 +1,56 @@
+import Orchestra.Monad.TaskStore
+import Orchestra.Monad.Queue
+import Orchestra.Project.Basic
+
+open Orchestra (MonadTaskStore MonadQueue generateTaskId currentIso8601 saveEntry)
+open Orchestra.Project (ProjectId IssueId PRRef Project ReviewerTemplate)
+
+namespace Orchestra.Project.Enqueue
+
+private def renderReviewerPrompt (tmpl : String) (pr : PRRef) (iid : IssueId) : String :=
+  tmpl.replace "{{repo}}"      pr.repo.toString
+    |>.replace "{{pr_number}}" (toString pr.number)
+    |>.replace "{{branch}}"    pr.branch
+    |>.replace "{{issue_id}}"  iid.value
+
+/-- Enqueue a merger task for `pr` so the queue daemon will merge it later.
+    Returns the new queue entry's ID. -/
+def enqueueMergerImpl [Monad m] [MonadTaskStore m] [MonadQueue m]
+    (pid : ProjectId) (iid : IssueId) (pr : PRRef) : m String := do
+  let id ← generateTaskId
+  let createdAt ← currentIso8601
+  let entry : Orchestra.Queue.QueueEntry :=
+    { id, createdAt
+    , upstream := pr.repo, fork := pr.repo
+    , mode := .pr
+    , prompt := s!"merge {pr.repo}#{pr.number}"
+    , backend := some "merger"
+    , projectId := some pid
+    , issueId := some iid
+    , priority := 100 }
+  saveEntry entry
+  return id
+
+/-- Enqueue a reviewer task for `pr` against `tmpl`.
+    Called by `attach_pr` when the project has a `reviewer` template configured.
+    Returns the new queue entry's ID. -/
+def enqueueReviewerImpl [Monad m] [MonadTaskStore m] [MonadQueue m]
+    (project : Project) (iid : IssueId) (pr : PRRef) (tmpl : ReviewerTemplate) : m String := do
+  let id ← generateTaskId
+  let createdAt ← currentIso8601
+  let entry : Orchestra.Queue.QueueEntry :=
+    { id, createdAt
+    , upstream := pr.repo, fork := pr.repo
+    , mode := .pr
+    , prompt := renderReviewerPrompt tmpl.promptTemplate pr iid
+    , backend := tmpl.backend
+    , projectId := some project.id
+    , issueId := some iid
+    , tools := some ["review_issues", "comment", "get_pr_comments"]
+    , readOnly := true
+    , issueNumber := some pr.number
+    , priority := 50 }
+  saveEntry entry
+  return id
+
+end Orchestra.Project.Enqueue

--- a/Orchestra/Project/Tools.lean
+++ b/Orchestra/Project/Tools.lean
@@ -1,9 +1,11 @@
 import Lean.Data.Json
+import Orchestra.Monad.Log
+import Orchestra.Monad.TaskStore
 import Orchestra.Project.Basic
 import Orchestra.Project.Claim
-import Orchestra.TaskStore
 
 open Lean (Json FromJson ToJson)
+open Orchestra (logInfo logError currentIso8601)
 
 namespace Orchestra.Project.Tools
 
@@ -375,14 +377,13 @@ structure Env where
   /-- Optional series the task belongs to. Stored alongside the claim. -/
   series : Option String := none
   /-- Hook called by `decideIssue .approve` to enqueue the merger task.
-      Receives (projectId, issueId, prRef). Returning `.ok ()` is success;
-      `.error msg` is surfaced to the agent. -/
-  enqueueMerger : Option (ProjectId → IssueId → PRRef → IO (Except String String)) := none
+      Receives (projectId, issueId, prRef). Throws on failure. -/
+  enqueueMerger : Option (ProjectId → IssueId → PRRef → IO String) := none
   /-- Optional auto-reviewer hook (F1). Called by `attachPr` when the
       project has a `reviewer` template configured. Receives
-      `(project, issueId, prRef, template)`. -/
+      `(project, issueId, prRef, template)`. Throws on failure. -/
   enqueueReviewer : Option
-    (Project → IssueId → PRRef → ReviewerTemplate → IO (Except String String)) := none
+    (Project → IssueId → PRRef → ReviewerTemplate → IO String) := none
   /-- Orchestra project this task belongs to. Used by `project_info`. -/
   projectId : Option ProjectId := none
   /-- Orchestra issue this task is working on. Used by `project_info`. -/
@@ -428,7 +429,7 @@ private def content (text : String) (isError : Bool := false) : Json :=
 /-! ## Evaluator -/
 
 def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
-  let now ← TaskStore.currentIso8601
+  let now ← currentIso8601
   match call with
   -- ---------------- manage_issues ----------------
   | .listProjects =>
@@ -530,11 +531,11 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     match ← findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
-      IO.println s!"  [mcp] claim_issue: {iid.value} \"{i.title}\""
+      logInfo s!"  [mcp] claim_issue: {iid.value} \"{i.title}\""
       match ← tryClaim mgr project.id iid taskId env.agentBackend now env.series with
       | .acquired _ =>
         let target := (effectiveTarget project i).map renderTarget |>.getD ""
-        IO.println s!"  [mcp] claim_issue: acquired (target={target})"
+        logInfo s!"  [mcp] claim_issue: acquired (target={target})"
         let payload := Json.mkObj
           [ ("ok", true)
           , ("issue_id",     Json.str iid.value)
@@ -542,14 +543,14 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
           , ("target",       Json.str target) ]
         return content payload.compress
       | .alreadyClaimed existing =>
-        IO.println s!"  [mcp] claim_issue: already claimed by task {existing.taskId}"
+        logInfo s!"  [mcp] claim_issue: already claimed by task {existing.taskId}"
         let payload := Json.mkObj
           [ ("ok", false)
           , ("error", Json.str "already_claimed")
           , ("held_by_task", Json.str existing.taskId) ]
         return content payload.compress (isError := true)
       | .invalid reason =>
-        IO.println s!"  [mcp] claim_issue: invalid — {reason}"
+        logInfo s!"  [mcp] claim_issue: invalid — {reason}"
         return content s!"invalid claim: {reason}" (isError := true)
   | .releaseClaim iid reason =>
     if !has env workIssuesPerm then return content (deny workIssuesPerm) (isError := true)
@@ -558,7 +559,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     match ← findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
-      IO.println s!"  [mcp] release_claim: {iid.value} \"{i.title}\" — {reason}"
+      logInfo s!"  [mcp] release_claim: {iid.value} \"{i.title}\" — {reason}"
       let newStatus := match i.status with
         | .blocked  => .blocked
         | .inReview => .inReview
@@ -581,7 +582,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
             s!"cannot attach PR to {iid.value}: held by task {claim.taskId}, not this task"
             (isError := true)
         else
-          IO.println s!"  [mcp] attach_pr: {iid.value} \"{i.title}\" ← {repo}#{number} (branch {branch})"
+          logInfo s!"  [mcp] attach_pr: {iid.value} \"{i.title}\" ← {repo}#{number} (branch {branch})"
           let pr : PRRef := { repo, number, branch, taskId := env.taskId }
           let updated : Issue :=
             { i with
@@ -592,13 +593,13 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
           -- F1: if the project configures an auto-reviewer, enqueue it now.
           let reviewerNote ← match project.reviewer, env.enqueueReviewer with
             | some tmpl, some hook =>
-              match ← hook project iid pr tmpl with
-              | .ok rid    =>
-                IO.println s!"  [mcp] attach_pr: reviewer task {rid} enqueued"
+              try
+                let rid ← hook project iid pr tmpl
+                logInfo s!"  [mcp] attach_pr: reviewer task {rid} enqueued"
                 pure s!"; reviewer task {rid} enqueued"
-              | .error msg =>
-                IO.println s!"  [mcp] attach_pr: reviewer enqueue failed — {msg}"
-                pure s!"; reviewer enqueue failed: {msg}"
+              catch e =>
+                logInfo s!"  [mcp] attach_pr: reviewer enqueue failed — {toString e}"
+                pure s!"; reviewer enqueue failed: {toString e}"
             | _, _ => pure ""
           return content
             s!"attached {repo}#{number} to {iid.value}; issue moved to in_review{reviewerNote}"
@@ -611,7 +612,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     match ← findIssue parentId with
     | none => return content s!"issue {parentId.value} not found" (isError := true)
     | some (project, parent) =>
-      IO.println s!"  [mcp] split_issue: {parentId.value} \"{parent.title}\" → {children.size} sub-issues — {reason}"
+      logInfo s!"  [mcp] split_issue: {parentId.value} \"{parent.title}\" → {children.size} sub-issues — {reason}"
       -- Caller must already hold the claim on this parent. We don't allow
       -- workers to split issues they don't own — that would let a stray
       -- agent rearrange someone else's work.
@@ -635,7 +636,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
               , target := spec.target <|> inheritedTarget
               , createdAt := now, updatedAt := now }
             saveIssue issue
-            IO.println s!"  [mcp] split_issue: created sub-issue {iid.value} \"{spec.title}\""
+            logInfo s!"  [mcp] split_issue: created sub-issue {iid.value} \"{spec.title}\""
             createdIds := createdIds.push iid.value
           -- Move parent to .blocked and clear the claim. We don't reuse
           -- `release` here because it sets status unconditionally; we want
@@ -662,7 +663,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
       let decisionStr := match decision with | .approve => "approve" | .reject => "reject"
-      IO.println s!"  [mcp] decide_issue: {iid.value} \"{i.title}\" → {decisionStr} — {notes}"
+      logInfo s!"  [mcp] decide_issue: {iid.value} \"{i.title}\" → {decisionStr} — {notes}"
       match decision with
       | .reject =>
         -- Move back to .open and clear any claim. Notes are echoed back; the
@@ -671,7 +672,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
           let _ ← release mgr project.id iid .open now
         else
           saveIssue { i with status := .open, updatedAt := now }
-        IO.println s!"  [mcp] decide_issue: {iid.value} moved to open"
+        logInfo s!"  [mcp] decide_issue: {iid.value} moved to open"
         return content s!"rejected {iid.value}: {notes}"
       | .approve =>
         match i.attachedPRs.toList.reverse with
@@ -681,13 +682,14 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
           | none =>
             return content "merger enqueue hook not configured" (isError := true)
           | some hook =>
-            match ← hook project.id iid pr with
-            | .error msg => return content s!"failed to enqueue merger: {msg}" (isError := true)
-            | .ok mergerTaskId =>
-              IO.println s!"  [mcp] decide_issue: {iid.value} approved; merger task {mergerTaskId} enqueued"
+            try
+              let mergerTaskId ← hook project.id iid pr
+              logInfo s!"  [mcp] decide_issue: {iid.value} approved; merger task {mergerTaskId} enqueued"
               return content s!"approved {iid.value}; merger task {mergerTaskId} enqueued ({notes})"
+            catch e =>
+              return content s!"failed to enqueue merger: {toString e}" (isError := true)
   | .projectInfo =>
-    IO.println "  [mcp] project_info"
+    logInfo "  [mcp] project_info"
     match env.projectId with
     | none => return content "this task is not attached to a project" (isError := true)
     | some pid =>

--- a/Orchestra/Project/Tools.lean
+++ b/Orchestra/Project/Tools.lean
@@ -3,9 +3,11 @@ import Orchestra.Monad.Log
 import Orchestra.Monad.TaskStore
 import Orchestra.Project.Basic
 import Orchestra.Project.Claim
+import Orchestra.Project.Enqueue
 
 open Lean (Json FromJson ToJson)
 open Orchestra (logInfo logError currentIso8601)
+open Orchestra.Project.Enqueue (enqueueMergerImpl enqueueReviewerImpl)
 
 namespace Orchestra.Project.Tools
 
@@ -376,14 +378,10 @@ structure Env where
   agentBackend : String := "unknown"
   /-- Optional series the task belongs to. Stored alongside the claim. -/
   series : Option String := none
-  /-- Hook called by `decideIssue .approve` to enqueue the merger task.
-      Receives (projectId, issueId, prRef). Throws on failure. -/
-  enqueueMerger : Option (ProjectId → IssueId → PRRef → IO String) := none
-  /-- Optional auto-reviewer hook (F1). Called by `attachPr` when the
-      project has a `reviewer` template configured. Receives
-      `(project, issueId, prRef, template)`. Throws on failure. -/
-  enqueueReviewer : Option
-    (Project → IssueId → PRRef → ReviewerTemplate → IO String) := none
+  /-- Whether `decideIssue .approve` is permitted to enqueue a merger task. -/
+  canEnqueueMerger : Bool := false
+  /-- Whether `attachPr` is permitted to enqueue an auto-reviewer task. -/
+  canEnqueueReviewer : Bool := false
   /-- Orchestra project this task belongs to. Used by `project_info`. -/
   projectId : Option ProjectId := none
   /-- Orchestra issue this task is working on. Used by `project_info`. -/
@@ -591,16 +589,18 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
               updatedAt   := now }
           saveIssue updated
           -- F1: if the project configures an auto-reviewer, enqueue it now.
-          let reviewerNote ← match project.reviewer, env.enqueueReviewer with
-            | some tmpl, some hook =>
-              try
-                let rid ← hook project iid pr tmpl
-                logInfo s!"  [mcp] attach_pr: reviewer task {rid} enqueued"
-                pure s!"; reviewer task {rid} enqueued"
-              catch e =>
-                logInfo s!"  [mcp] attach_pr: reviewer enqueue failed — {toString e}"
-                pure s!"; reviewer enqueue failed: {toString e}"
-            | _, _ => pure ""
+          let reviewerNote ← match project.reviewer with
+            | some tmpl =>
+              if env.canEnqueueReviewer then
+                try
+                  let rid ← enqueueReviewerImpl project iid pr tmpl
+                  logInfo s!"  [mcp] attach_pr: reviewer task {rid} enqueued"
+                  pure s!"; reviewer task {rid} enqueued"
+                catch e =>
+                  logInfo s!"  [mcp] attach_pr: reviewer enqueue failed — {toString e}"
+                  pure s!"; reviewer enqueue failed: {toString e}"
+              else pure ""
+            | none => pure ""
           return content
             s!"attached {repo}#{number} to {iid.value}; issue moved to in_review{reviewerNote}"
   | .splitIssue parentId children reason =>
@@ -678,16 +678,14 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
         match i.attachedPRs.toList.reverse with
         | [] => return content "no attached PRs to merge" (isError := true)
         | pr :: _ =>
-          match env.enqueueMerger with
-          | none =>
-            return content "merger enqueue hook not configured" (isError := true)
-          | some hook =>
-            try
-              let mergerTaskId ← hook project.id iid pr
-              logInfo s!"  [mcp] decide_issue: {iid.value} approved; merger task {mergerTaskId} enqueued"
-              return content s!"approved {iid.value}; merger task {mergerTaskId} enqueued ({notes})"
-            catch e =>
-              return content s!"failed to enqueue merger: {toString e}" (isError := true)
+          if !env.canEnqueueMerger then
+            return content "merger enqueue not available in this context" (isError := true)
+          try
+            let mergerTaskId ← enqueueMergerImpl project.id iid pr
+            logInfo s!"  [mcp] decide_issue: {iid.value} approved; merger task {mergerTaskId} enqueued"
+            return content s!"approved {iid.value}; merger task {mergerTaskId} enqueued ({notes})"
+          catch e =>
+            return content s!"failed to enqueue merger: {toString e}" (isError := true)
   | .projectInfo =>
     logInfo "  [mcp] project_info"
     match env.projectId with

--- a/Orchestra/Project/Tools.lean
+++ b/Orchestra/Project/Tools.lean
@@ -1,12 +1,13 @@
 import Lean.Data.Json
 import Orchestra.Monad.Log
 import Orchestra.Monad.TaskStore
-import Orchestra.Project.Basic
-import Orchestra.Project.Claim
+import Orchestra.Monad.Queue
+import Orchestra.Monad.Project
+import Orchestra.Monad.Claim
 import Orchestra.Project.Enqueue
 
 open Lean (Json FromJson ToJson)
-open Orchestra (logInfo logError currentIso8601)
+open Orchestra (logInfo logError currentIso8601 MonadProject MonadClaim)
 open Orchestra.Project.Enqueue (enqueueMergerImpl enqueueReviewerImpl)
 
 namespace Orchestra.Project.Tools
@@ -426,32 +427,34 @@ private def content (text : String) (isError : Bool := false) : Json :=
 
 /-! ## Evaluator -/
 
-def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
+def evalProjectTool [Monad m] [MonadProject m] [MonadClaim m] [MonadLog m]
+    [MonadTaskStore m] [MonadQueue m] [MonadExcept IO.Error m]
+    (env : Env) (call : ProjectTool) : m Json := do
   let now ← currentIso8601
   match call with
   -- ---------------- manage_issues ----------------
   | .listProjects =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
-    let projects ← loadAllProjects
+    let projects ← MonadProject.loadAllProjects
     if projects.isEmpty then return content "No projects."
     return content (joinLines (projects.map projectLine))
   | .listIssues pid statusFilter parentId =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
-    let some _ ← loadProject pid
+    let some _ ← MonadProject.loadProject pid
       | return content s!"project {pid.value} not found" (isError := true)
-    let mut issues ← loadIssues pid
+    let mut issues ← MonadProject.loadIssues pid
     if let some s := statusFilter then issues := issues.filter (·.status == s)
     if let some p := parentId then issues := issues.filter (·.parentId == some p)
     if issues.isEmpty then return content "No matching issues."
     return content (joinLines (issues.map issueLine))
   | .getIssue iid =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
-    match ← findIssue iid with
+    match ← MonadProject.findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
       let target := (effectiveTarget project i).map renderTarget |>.getD "-"
       let prs := i.attachedPRs.map (fun p => s!"  - {p.repo}#{p.number} (branch {p.branch})")
-      let children ← childrenOf project.id i.id
+      let children ← MonadProject.childrenOf project.id i.id
       let childLines := children.map (fun c => s!"  - {c.id.value}  [{issueStatusToString c.status}]  {c.title}")
       let depsStr := if i.dependencies.isEmpty then "-"
                      else String.intercalate ", " (i.dependencies.map (·.value)).toList
@@ -473,25 +476,25 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
       return content (joinLines body)
   | .createIssue pid title descr parent target dependencies =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
-    let some project ← loadProject pid
+    let some project ← MonadProject.loadProject pid
       | return content s!"project {pid.value} not found" (isError := true)
     if target.isNone && project.defaultTarget.isNone then
       return content
         "project has no default target; pass target_repo and target_branch" (isError := true)
     if let some parentId := parent then
-      match ← findIssue parentId with
+      match ← MonadProject.findIssue parentId with
       | none => return content s!"parent issue {parentId.value} not found" (isError := true)
       | some (_, parentIssue) =>
-        saveIssue { parentIssue with status := .blocked, updatedAt := now }
-    let iid ← freshIssueId
+        MonadProject.saveIssue { parentIssue with status := .blocked, updatedAt := now }
+    let iid ← MonadProject.freshIssueId
     let issue : Issue :=
       { id := iid, projectId := pid, parentId := parent, title, description := descr
       , target, dependencies, createdAt := now, updatedAt := now }
-    saveIssue issue
+    MonadProject.saveIssue issue
     return content s!"created issue {iid.value} in project {pid.value}"
   | .updateIssue iid title descr status target dependencies =>
     if !has env manageIssuesPerm then return content (deny manageIssuesPerm) (isError := true)
-    match ← findIssue iid with
+    match ← MonadProject.findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (_, i) =>
       let updated : Issue :=
@@ -502,14 +505,14 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
           target       := match target with | some t => some t | none => i.target
           dependencies := dependencies.getD i.dependencies
           updatedAt    := now }
-      saveIssue updated
+      MonadProject.saveIssue updated
       return content s!"updated issue {iid.value}"
   -- ---------------- work_issues ----------------
   | .listOpenIssues pid targetRepo? =>
     if !has env workIssuesPerm then return content (deny workIssuesPerm) (isError := true)
-    let some project ← loadProject pid
+    let some project ← MonadProject.loadProject pid
       | return content s!"project {pid.value} not found" (isError := true)
-    let issues ← loadIssues pid
+    let issues ← MonadProject.loadIssues pid
     let openIssues := issues.filter (·.status == .open)
     let filtered := match targetRepo? with
       | none => openIssues
@@ -526,11 +529,11 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
       | return content "claim manager not available in this context" (isError := true)
     let some taskId := env.taskId
       | return content "no task id in context (cannot record claim)" (isError := true)
-    match ← findIssue iid with
+    match ← MonadProject.findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
       logInfo s!"  [mcp] claim_issue: {iid.value} \"{i.title}\""
-      match ← tryClaim mgr project.id iid taskId env.agentBackend now env.series with
+      match ← MonadClaim.tryClaim mgr project.id iid taskId env.agentBackend now env.series with
       | .acquired _ =>
         let target := (effectiveTarget project i).map renderTarget |>.getD ""
         logInfo s!"  [mcp] claim_issue: acquired (target={target})"
@@ -554,7 +557,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     if !has env workIssuesPerm then return content (deny workIssuesPerm) (isError := true)
     let some mgr := env.claimManager
       | return content "claim manager not available in this context" (isError := true)
-    match ← findIssue iid with
+    match ← MonadProject.findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
       logInfo s!"  [mcp] release_claim: {iid.value} \"{i.title}\" — {reason}"
@@ -562,16 +565,16 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
         | .blocked  => .blocked
         | .inReview => .inReview
         | _         => .open
-      let _ ← release mgr project.id iid newStatus now
+      let _ ← MonadClaim.release mgr project.id iid newStatus now
       return content s!"released claim on {iid.value} ({reason})"
   | .attachPr iid repo number branch =>
     if !has env workIssuesPerm then return content (deny workIssuesPerm) (isError := true)
     let some taskId := env.taskId
       | return content "no task id in context (cannot verify claim ownership)" (isError := true)
-    match ← findIssue iid with
+    match ← MonadProject.findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
-      match ← loadClaim project.id iid with
+      match ← MonadClaim.loadClaim project.id iid with
       | none =>
         return content s!"cannot attach PR to {iid.value}: issue is not claimed" (isError := true)
       | some claim =>
@@ -587,7 +590,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
               attachedPRs := i.attachedPRs.push pr
               status      := .inReview
               updatedAt   := now }
-          saveIssue updated
+          MonadProject.saveIssue updated
           -- F1: if the project configures an auto-reviewer, enqueue it now.
           let reviewerNote ← match project.reviewer with
             | some tmpl =>
@@ -609,14 +612,14 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
       | return content "claim manager not available in this context" (isError := true)
     let some taskId := env.taskId
       | return content "no task id in context (cannot verify claim ownership)" (isError := true)
-    match ← findIssue parentId with
+    match ← MonadProject.findIssue parentId with
     | none => return content s!"issue {parentId.value} not found" (isError := true)
     | some (project, parent) =>
       logInfo s!"  [mcp] split_issue: {parentId.value} \"{parent.title}\" → {children.size} sub-issues — {reason}"
       -- Caller must already hold the claim on this parent. We don't allow
       -- workers to split issues they don't own — that would let a stray
       -- agent rearrange someone else's work.
-      match ← loadClaim project.id parentId with
+      match ← MonadClaim.loadClaim project.id parentId with
       | none =>
         return content s!"cannot split {parentId.value}: not currently claimed" (isError := true)
       | some claim =>
@@ -628,21 +631,21 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
           let inheritedTarget := effectiveTarget project parent
           let mut createdIds : Array String := #[]
           for spec in children do
-            let iid ← freshIssueId
+            let iid ← MonadProject.freshIssueId
             let issue : Issue :=
               { id := iid, projectId := project.id
               , parentId := some parentId
               , title := spec.title, description := spec.description
               , target := spec.target <|> inheritedTarget
               , createdAt := now, updatedAt := now }
-            saveIssue issue
+            MonadProject.saveIssue issue
             logInfo s!"  [mcp] split_issue: created sub-issue {iid.value} \"{spec.title}\""
             createdIds := createdIds.push iid.value
           -- Move parent to .blocked and clear the claim. We don't reuse
           -- `release` here because it sets status unconditionally; we want
           -- `.blocked` specifically.
-          saveIssue { parent with status := .blocked, updatedAt := now }
-          let _ ← forceRelease mgr project.id parentId
+          MonadProject.saveIssue { parent with status := .blocked, updatedAt := now }
+          let _ ← MonadClaim.forceRelease mgr project.id parentId
           let payload := Json.mkObj
             [ ("ok",         true)
             , ("parent_id",  Json.str parentId.value)
@@ -652,14 +655,14 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
   -- ---------------- review_issues ----------------
   | .listIssuesInReview pid =>
     if !has env reviewIssuesPerm then return content (deny reviewIssuesPerm) (isError := true)
-    let some _ ← loadProject pid
+    let some _ ← MonadProject.loadProject pid
       | return content s!"project {pid.value} not found" (isError := true)
-    let issues := (← loadIssues pid).filter (·.status == .inReview)
+    let issues := (← MonadProject.loadIssues pid).filter (·.status == .inReview)
     if issues.isEmpty then return content "No issues awaiting review."
     return content (joinLines (issues.map issueLine))
   | .decideIssue iid decision notes =>
     if !has env reviewIssuesPerm then return content (deny reviewIssuesPerm) (isError := true)
-    match ← findIssue iid with
+    match ← MonadProject.findIssue iid with
     | none => return content s!"issue {iid.value} not found" (isError := true)
     | some (project, i) =>
       let decisionStr := match decision with | .approve => "approve" | .reject => "reject"
@@ -669,9 +672,9 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
         -- Move back to .open and clear any claim. Notes are echoed back; the
         -- comment tool is the right place to post them on the PR if desired.
         if let some mgr := env.claimManager then
-          let _ ← release mgr project.id iid .open now
+          let _ ← MonadClaim.release mgr project.id iid .open now
         else
-          saveIssue { i with status := .open, updatedAt := now }
+          MonadProject.saveIssue { i with status := .open, updatedAt := now }
         logInfo s!"  [mcp] decide_issue: {iid.value} moved to open"
         return content s!"rejected {iid.value}: {notes}"
       | .approve =>
@@ -691,7 +694,7 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
     match env.projectId with
     | none => return content "this task is not attached to a project" (isError := true)
     | some pid =>
-      match ← loadProject pid with
+      match ← MonadProject.loadProject pid with
       | none => return content s!"project {pid.value} not found" (isError := true)
       | some project =>
         let mut lines : Array String := #[
@@ -701,13 +704,13 @@ def evalProjectTool (env : Env) (call : ProjectTool) : IO Json := do
         match env.issueId with
         | none => lines := lines.push "issue:        none"
         | some iid =>
-          match ← findIssue iid with
+          match ← MonadProject.findIssue iid with
           | none => lines := lines.push s!"issue_id:     {iid.value} (not found)"
           | some (_, issue) =>
             lines := lines.push s!"issue_id:     {issue.id.value}"
             lines := lines.push s!"issue_title:  {issue.title}"
             lines := lines.push s!"issue_status: {issueStatusToString issue.status}"
-            if let some claim ← loadClaim project.id iid then
+            if let some claim ← MonadClaim.loadClaim project.id iid then
               if some claim.taskId == env.taskId then
                 lines := lines.push s!"claim:        held by this task (since {claim.claimedAt})"
               else

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -3,11 +3,15 @@ import Std.Internal.UV.TCP
 import Std.Net
 import Orchestra.Config
 import Orchestra.GitHub
+import Orchestra.Monad
 import Orchestra.Project.Tools
 
 open Lean (Json)
 open Std.Net
 open Std.Internal.UV.TCP
+open Orchestra (logError createJWT getInstallationId createInstallationToken setupGhAuth
+  createPullRequest createPullRequestOnRepo getPrReviewThreads createIssueComment
+  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber)
 
 namespace Orchestra.Server
 
@@ -49,15 +53,10 @@ structure State where
   /-- Hook that enqueues a merger task, set by the daemon. Plumbed by
       `Project.Tools.Env` so `decide_issue approve` can request a merge. -/
   enqueueMerger : Option (Project.ProjectId → Project.IssueId → Project.PRRef →
-                          IO (Except String String)) := none
+                          IO String) := none
   /-- Optional auto-reviewer hook (F1). Plumbed to `Project.Tools.Env.enqueueReviewer`. -/
   enqueueReviewer : Option (Project.Project → Project.IssueId → Project.PRRef →
-                            Project.ReviewerTemplate → IO (Except String String)) := none
-
-private def log (msg : String) : IO Unit := do
-  let err ← IO.getStderr
-  err.putStrLn s!"[mcp] {msg}"
-  err.flush
+                            Project.ReviewerTemplate → IO String) := none
 
 -- JSON-RPC helpers
 
@@ -417,124 +416,124 @@ def parseRequest (msg : Json) : Option Request :=
 private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
   match call with
   | .health =>
-    log "tool health"
+    logError "[mcp] tool health"
     return toolContent "ok"
   | .refreshToken =>
-    log "tool refresh_token: creating new installation token"
+    logError "[mcp] tool refresh_token: creating new installation token"
     try
-      let jwt ← GitHub.createJWT state.appId state.privateKeyPath
-      let token ← GitHub.createInstallationToken jwt state.installationId
-      GitHub.setupGhAuth token
-      log "tool refresh_token: ok"
+      let jwt ← createJWT state.appId state.privateKeyPath
+      let token ← createInstallationToken jwt state.installationId
+      setupGhAuth token
+      logError "[mcp] tool refresh_token: ok"
       return toolContent token
     catch e =>
-      log s!"tool refresh_token: error: {e}"
+      logError s!"[mcp] tool refresh_token: error: {e}"
       return toolContent (toString e) (isError := true)
   | .createPr title body head base target =>
     if !state.allowedTools.contains "create_pr" then
-      log "tool create_pr: denied (not in allowed tools)"
+      logError "[mcp] tool create_pr: denied (not in allowed tools)"
       return toolContent "PR creation is not enabled for this task" (isError := true)
     match target with
     | .upstream =>
       if state.pat.isEmpty then
-        log "tool create_pr: error: PAT not configured (target=upstream)"
+        logError "[mcp] tool create_pr: error: PAT not configured (target=upstream)"
         return toolContent
           "github.pat not set in config (required when target=upstream; pass target=\"fork\" to use the App token)"
           (isError := true)
-      log s!"tool create_pr [upstream]: {state.fork}:{head} -> {state.upstream} base={base} title={repr title}"
+      logError s!"[mcp] tool create_pr [upstream]: {state.fork}:{head} -> {state.upstream} base={base} title={repr title}"
       try
-        let result ← GitHub.createPullRequest state.pat state.upstream
+        let result ← createPullRequest state.pat state.upstream
           s!"{state.fork.owner}:{head}" base title body
-        log s!"tool create_pr: ok: {result.trimAscii}"
+        logError s!"[mcp] tool create_pr: ok: {result.trimAscii}"
         return toolContent result
       catch e =>
-        log s!"tool create_pr: error: {e}"
+        logError s!"[mcp] tool create_pr: error: {e}"
         return toolContent (toString e) (isError := true)
     | .fork =>
-      log s!"tool create_pr [fork]: {state.fork}:{head} base={base} title={repr title}"
+      logError s!"[mcp] tool create_pr [fork]: {state.fork}:{head} base={base} title={repr title}"
       try
         -- Mint a fresh installation token so the PR is attributed to the
         -- GitHub App, not the PAT owner.
-        let jwt ← GitHub.createJWT state.appId state.privateKeyPath
-        let token ← GitHub.createInstallationToken jwt state.installationId
-        let result ← GitHub.createPullRequestOnRepo token state.fork
+        let jwt ← createJWT state.appId state.privateKeyPath
+        let token ← createInstallationToken jwt state.installationId
+        let result ← createPullRequestOnRepo token state.fork
           head base title body
-        log s!"tool create_pr: ok: {result.trimAscii}"
+        logError s!"[mcp] tool create_pr: ok: {result.trimAscii}"
         return toolContent result
       catch e =>
-        log s!"tool create_pr: error: {e}"
+        logError s!"[mcp] tool create_pr: error: {e}"
         return toolContent (toString e) (isError := true)
   | .getPrComments prNumber unresolvedOnly excludeOutdated =>
-    log s!"tool get_pr_comments: pr={prNumber} unresolved_only={unresolvedOnly} \
+    logError s!"[mcp] tool get_pr_comments: pr={prNumber} unresolved_only={unresolvedOnly} \
       exclude_outdated={excludeOutdated}"
     try
-      let response ← GitHub.getPrReviewThreads state.upstream prNumber state.pat
+      let response ← getPrReviewThreads state.upstream prNumber state.pat
       let text := GitHub.formatPrReviewThreads response unresolvedOnly excludeOutdated
-      log "tool get_pr_comments: ok"
+      logError "[mcp] tool get_pr_comments: ok"
       return toolContent text
     catch e =>
-      log s!"tool get_pr_comments: error: {e}"
+      logError s!"[mcp] tool get_pr_comments: error: {e}"
       return toolContent (toString e) (isError := true)
   | .comment action =>
     if !state.allowedTools.contains "comment" then
-      log "tool comment: denied (not in allowed tools)"
+      logError "[mcp] tool comment: denied (not in allowed tools)"
       return toolContent "comment tool is not enabled for this task" (isError := true)
     match state.issueNumber with
     | none =>
-      log "tool comment: no issue number configured"
+      logError "[mcp] tool comment: no issue number configured"
       return toolContent "no issue_number configured for this task" (isError := true)
     | some n =>
       match action with
       | .issue body =>
-        log s!"tool comment: posting to {state.upstream}#{n}"
+        logError s!"[mcp] tool comment: posting to {state.upstream}#{n}"
         try
-          let result ← GitHub.createIssueComment state.pat state.upstream n body
-          log "tool comment: ok"
+          let result ← createIssueComment state.pat state.upstream n body
+          logError "[mcp] tool comment: ok"
           return toolContent result
         catch e =>
-          log s!"tool comment: error: {e}"
+          logError s!"[mcp] tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
       | .review body inlineComments =>
-        log s!"tool comment: posting review to {state.upstream}#{n} \
+        logError s!"[mcp] tool comment: posting review to {state.upstream}#{n} \
           ({inlineComments.size} inline comments)"
         try
-          let result ← GitHub.createPrReview state.pat state.upstream n body inlineComments
-          log "tool comment: ok"
+          let result ← createPrReview state.pat state.upstream n body inlineComments
+          logError "[mcp] tool comment: ok"
           return toolContent result
         catch e =>
-          log s!"tool comment: error: {e}"
+          logError s!"[mcp] tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
       | .replyInline body cid =>
-        log s!"tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
+        logError s!"[mcp] tool comment: replying to inline comment {cid} on {state.upstream}#{n}"
         try
-          let cidPr ← GitHub.getPrReviewCommentPrNumber state.pat state.upstream cid
+          let cidPr ← getPrReviewCommentPrNumber state.pat state.upstream cid
           if cidPr ≠ n then
-            log s!"tool comment: comment {cid} belongs to PR #{cidPr}, not #{n}"
+            logError s!"[mcp] tool comment: comment {cid} belongs to PR #{cidPr}, not #{n}"
             return toolContent s!"comment {cid} does not belong to issue #{n}" (isError := true)
-          let result ← GitHub.replyToPrReviewComment state.pat state.upstream n cid body
-          log "tool comment: ok"
+          let result ← replyToPrReviewComment state.pat state.upstream n cid body
+          logError "[mcp] tool comment: ok"
           return toolContent result
         catch e =>
-          log s!"tool comment: error: {e}"
+          logError s!"[mcp] tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
       | .newInline comment =>
-        log s!"tool comment: new inline comment on {state.upstream}#{n} \
+        logError s!"[mcp] tool comment: new inline comment on {state.upstream}#{n} \
           {comment.path}:{comment.line} ({comment.side})"
         try
-          let result ← GitHub.createPrReviewComment state.pat state.upstream n
+          let result ← createPrReviewComment state.pat state.upstream n
             comment.body comment.path comment.line comment.side
-          log "tool comment: ok"
+          logError "[mcp] tool comment: ok"
           return toolContent result
         catch e =>
-          log s!"tool comment: error: {e}"
+          logError s!"[mcp] tool comment: error: {e}"
           return toolContent (toString e) (isError := true)
   | .getTaskInput =>
-    log "tool get_task_input"
+    logError "[mcp] tool get_task_input"
     match state.inputJson with
     | some j => return toolContent j.compress
     | none   => return toolContent "no input available" (isError := true)
   | .submitTaskOutput value =>
-    log s!"tool submit_task_output: {value.compress.take 200}"
+    logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
     match state.outputRef with
     | some ref =>
       ref.set (some value)
@@ -554,29 +553,29 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       , enqueueReviewer := state.enqueueReviewer }
     Project.Tools.evalProjectTool env call
   | .unknown name =>
-    log s!"tool {name}: unknown"
+    logError s!"[mcp] tool {name}: unknown"
     return toolContent s!"unknown tool: {name}" (isError := true)
   | .parseError msg =>
-    log s!"tool call error: {msg}"
+    logError s!"[mcp] tool call error: {msg}"
     return toolContent msg (isError := true)
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
 private def evalRequest (state : State) (req : Request) : IO (Option Json) := do
   match req with
   | .initialize id =>
-    log "initialize"
+    logError "[mcp] initialize"
     return some (jsonrpcResult id initializeResult)
   | .initialized =>
-    log "initialized"
+    logError "[mcp] initialized"
     return none
   | .toolsList id =>
-    log "tools/list"
+    logError "[mcp] tools/list"
     return some (jsonrpcResult id (toolsList state))
   | .toolsCall id call =>
     let result ← evalToolCall state call
     return some (jsonrpcResult id result)
   | .unknown id method =>
-    log s!"unknown method: {method}"
+    logError s!"[mcp] unknown method: {method}"
     return some (jsonrpcError id (-32601) s!"method not found: {method}")
 
 -- TCP transport (raw JSON-RPC, newline-delimited)
@@ -635,10 +634,10 @@ def start (state : State) : IO (UInt16 × IO Unit) := do
       | .ok client =>
         if !(← running.get) then break
         let _ ← IO.asTask (prio := .dedicated) do
-          log "client connected"
+          logError "[mcp] client connected"
           try handleClient state client
           catch _ => pure ()
-          log "client disconnected"
+          logError "[mcp] client disconnected"
   let shutdown : IO Unit := do
     running.set false
     try

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -9,15 +9,20 @@ import Orchestra.Project.Tools
 open Lean (Json)
 open Std.Net
 open Std.Internal.UV.TCP
-open Orchestra (MonadLog MonadGitHubApp MonadGitHub
+open Orchestra (MonadLog MonadGitHubApp MonadGitHub MonadProjectTool
   logError createJWT getInstallationId createInstallationToken setupGhAuth
   createPullRequest createPullRequestOnRepo getPrReviewThreads createIssueComment
-  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber)
+  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber
+  evalProjectTool)
 
 namespace Orchestra.Server
 
-/-- Mutable state for the server, shared with request handlers. -/
-structure State where
+/-- Mutable state for the server, shared with request handlers.
+    Parameterised by the effect monad `m` so that the output-submission
+    callback can be stored as a plain `m`-action rather than a raw
+    `IO.Ref`, avoiding the need for a `MonadLiftT IO m` constraint in
+    the request evaluators. -/
+structure State (m : Type → Type) where
   upstream : Repository
   fork : Repository
   /-- Optional tools enabled for this run.
@@ -34,8 +39,10 @@ structure State where
   outputType : ResultType := .unit
   /-- The task input serialized as JSON. `none` when `inputType = .unit`. -/
   inputJson : Option Json := none
-  /-- Mutable cell where the agent stores its typed output via `submit_task_output`. -/
-  outputRef : Option (IO.Ref (Option Json)) := none
+  /-- Action invoked when the agent calls `submit_task_output`.  The caller
+      wires this to whatever storage it needs (e.g. `fun j => ref.set (some j)`);
+      `none` when output submission is not available for this task. -/
+  submitOutput : Option (Json → m Unit) := none
   /-- Issue or PR number this task was launched from. Required for the `comment` tool. -/
   issueNumber : Option Nat := none
   /-- Claim manager handle. Required for `claim_issue` / `release_claim` /
@@ -251,7 +258,7 @@ Call this tool exactly once when the task is complete."),
       ]]
   inputTool ++ outputTool
 
-private def toolsList (state : State) : Json :=
+private def toolsList {m : Type → Type} (state : State m) : Json :=
   let optional := optionalToolDefs.filterMap fun entry =>
     if state.allowedTools.contains entry.1 then some entry.2 else none
   let project := Project.Tools.toolDefs.filterMap fun (perm, _name, def_) =>
@@ -415,7 +422,7 @@ def parseRequest (msg : Json) : Option Request :=
 -- Evaluation
 
 private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (call : ToolCall) : m Json := do
+    [MonadProjectTool m] [MonadExceptOf IO.Error m] (state : State m) (call : ToolCall) : m Json := do
   match call with
   | .health =>
     logError "[mcp] tool health"
@@ -537,9 +544,9 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
     | none   => return toolContent "no input available" (isError := true)
   | .submitTaskOutput value =>
     logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
-    match state.outputRef with
-    | some ref =>
-      MonadLiftT.monadLift (m := IO) (ref.set (some value))
+    match state.submitOutput with
+    | some f =>
+      f value
       return toolContent "output recorded"
     | none =>
       return toolContent "output submission not available for this task" (isError := true)
@@ -554,7 +561,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
       , issueId       := state.issueId
       , enqueueMerger   := state.enqueueMerger
       , enqueueReviewer := state.enqueueReviewer }
-    MonadLiftT.monadLift (m := IO) (Project.Tools.evalProjectTool env call)
+    evalProjectTool env call
   | .unknown name =>
     logError s!"[mcp] tool {name}: unknown"
     return toolContent s!"unknown tool: {name}" (isError := true)
@@ -564,7 +571,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
 private def evalRequest [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (req : Request) : m (Option Json) := do
+    [MonadProjectTool m] [MonadExceptOf IO.Error m] (state : State m) (req : Request) : m (Option Json) := do
   match req with
   | .initialize id =>
     logError "[mcp] initialize"
@@ -596,7 +603,7 @@ Reads newline-delimited JSON messages, dispatches them, and writes responses.
 A line buffer handles the case where a single TCP receive spans multiple messages
 or a message is split across multiple receives.
 -/
-private def handleClient (state : State) (client : Socket) : IO Unit := do
+private def handleClient (state : State IO) (client : Socket) : IO Unit := do
   let buf ← IO.mkRef ""
   repeat do
     let data? ← awaitTcp (← client.recv? 65536)
@@ -622,7 +629,7 @@ private def handleClient (state : State) (client : Socket) : IO Unit := do
               let _ ← awaitTcp (← client.send #[(response.compress ++ "\n").toUTF8])
 
 /-- Start the MCP server. Returns (port, shutdown action). -/
-def start (state : State) : IO (UInt16 × IO Unit) := do
+def start (state : State IO) : IO (UInt16 × IO Unit) := do
   let server ← Socket.new
   let addr := SocketAddress.v4 { addr := IPv4Addr.ofParts 127 0 0 1, port := 0 }
   server.bind addr

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -539,7 +539,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
     logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
     match state.outputRef with
     | some ref =>
-      liftM (ref.set (some value))
+      liftM (α := Unit) (m := IO) (ref.set (some value))
       return toolContent "output recorded"
     | none =>
       return toolContent "output submission not available for this task" (isError := true)
@@ -596,18 +596,17 @@ Reads newline-delimited JSON messages, dispatches them, and writes responses.
 A line buffer handles the case where a single TCP receive spans multiple messages
 or a message is split across multiple receives.
 -/
-private def handleClient [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (client : Socket) : m Unit := do
-  let buf ← liftM (IO.mkRef "")
+private def handleClient (state : State) (client : Socket) : IO Unit := do
+  let buf ← IO.mkRef ""
   repeat do
-    let data? ← liftM do awaitTcp (← client.recv? 65536)
+    let data? ← awaitTcp (← client.recv? 65536)
     match data? with
     | none => return
     | some bytes =>
-      liftM (buf.modify (· ++ String.fromUTF8! bytes))
-      let lines := (← liftM buf.get).splitOn "\n"
+      buf.modify (· ++ String.fromUTF8! bytes)
+      let lines := (← buf.get).splitOn "\n"
       -- All elements except the last are complete lines; the last may be partial.
-      liftM (buf.set (lines.getLast?.getD ""))
+      buf.set (lines.getLast?.getD "")
       for line in lines.dropLast do
         let trimmed := line.trimAscii.toString
         if trimmed.isEmpty then continue
@@ -620,7 +619,7 @@ private def handleClient [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
             match ← evalRequest state req with
             | none => pure ()
             | some response =>
-              let _ ← liftM do awaitTcp (← client.send #[(response.compress ++ "\n").toUTF8])
+              let _ ← awaitTcp (← client.send #[(response.compress ++ "\n").toUTF8])
 
 /-- Start the MCP server. Returns (port, shutdown action). -/
 def start (state : State) : IO (UInt16 × IO Unit) := do

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -12,8 +12,7 @@ open Std.Internal.UV.TCP
 open Orchestra (MonadLog MonadGitHubApp MonadGitHub MonadProjectTool
   logError createJWT getInstallationId createInstallationToken setupGhAuth
   createPullRequest createPullRequestOnRepo getPrReviewThreads createIssueComment
-  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber
-  evalProjectTool)
+  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber)
 
 namespace Orchestra.Server
 
@@ -561,7 +560,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
       , issueId       := state.issueId
       , enqueueMerger   := state.enqueueMerger
       , enqueueReviewer := state.enqueueReviewer }
-    evalProjectTool env call
+    MonadProjectTool.evalProjectTool env call
   | .unknown name =>
     logError s!"[mcp] tool {name}: unknown"
     return toolContent s!"unknown tool: {name}" (isError := true)

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -415,7 +415,7 @@ def parseRequest (msg : Json) : Option Request :=
 -- Evaluation
 
 private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] (state : State) (call : ToolCall) : m Json := do
+    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (call : ToolCall) : m Json := do
   match call with
   | .health =>
     logError "[mcp] tool health"
@@ -564,7 +564,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
 private def evalRequest [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] (state : State) (req : Request) : m (Option Json) := do
+    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (req : Request) : m (Option Json) := do
   match req with
   | .initialize id =>
     logError "[mcp] initialize"
@@ -597,7 +597,7 @@ A line buffer handles the case where a single TCP receive spans multiple message
 or a message is split across multiple receives.
 -/
 private def handleClient [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] (state : State) (client : Socket) : m Unit := do
+    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (client : Socket) : m Unit := do
   let buf ← liftM (IO.mkRef "")
   repeat do
     let data? ← liftM do awaitTcp (← client.recv? 65536)

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -9,7 +9,8 @@ import Orchestra.Project.Tools
 open Lean (Json)
 open Std.Net
 open Std.Internal.UV.TCP
-open Orchestra (logError createJWT getInstallationId createInstallationToken setupGhAuth
+open Orchestra (MonadLog MonadGitHubApp MonadGitHub
+  logError createJWT getInstallationId createInstallationToken setupGhAuth
   createPullRequest createPullRequestOnRepo getPrReviewThreads createIssueComment
   replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber)
 
@@ -413,7 +414,8 @@ def parseRequest (msg : Json) : Option Request :=
 
 -- Evaluation
 
-private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
+private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
+    [MonadLiftT IO m] (state : State) (call : ToolCall) : m Json := do
   match call with
   | .health =>
     logError "[mcp] tool health"
@@ -537,7 +539,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
     logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
     match state.outputRef with
     | some ref =>
-      ref.set (some value)
+      liftM (ref.set (some value))
       return toolContent "output recorded"
     | none =>
       return toolContent "output submission not available for this task" (isError := true)
@@ -552,7 +554,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       , issueId       := state.issueId
       , enqueueMerger   := state.enqueueMerger
       , enqueueReviewer := state.enqueueReviewer }
-    Project.Tools.evalProjectTool env call
+    liftM (Project.Tools.evalProjectTool env call)
   | .unknown name =>
     logError s!"[mcp] tool {name}: unknown"
     return toolContent s!"unknown tool: {name}" (isError := true)
@@ -561,7 +563,8 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
     return toolContent msg (isError := true)
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
-private def evalRequest (state : State) (req : Request) : IO (Option Json) := do
+private def evalRequest [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
+    [MonadLiftT IO m] (state : State) (req : Request) : m (Option Json) := do
   match req with
   | .initialize id =>
     logError "[mcp] initialize"
@@ -593,17 +596,18 @@ Reads newline-delimited JSON messages, dispatches them, and writes responses.
 A line buffer handles the case where a single TCP receive spans multiple messages
 or a message is split across multiple receives.
 -/
-private def handleClient (state : State) (client : Socket) : IO Unit := do
-  let buf ← IO.mkRef ""
+private def handleClient [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
+    [MonadLiftT IO m] (state : State) (client : Socket) : m Unit := do
+  let buf ← liftM (IO.mkRef "")
   repeat do
-    let data? ← awaitTcp (← client.recv? 65536)
+    let data? ← liftM do awaitTcp (← client.recv? 65536)
     match data? with
     | none => return
     | some bytes =>
-      buf.modify (· ++ String.fromUTF8! bytes)
-      let lines := (← buf.get).splitOn "\n"
+      liftM (buf.modify (· ++ String.fromUTF8! bytes))
+      let lines := (← liftM buf.get).splitOn "\n"
       -- All elements except the last are complete lines; the last may be partial.
-      buf.set (lines.getLast?.getD "")
+      liftM (buf.set (lines.getLast?.getD ""))
       for line in lines.dropLast do
         let trimmed := line.trimAscii.toString
         if trimmed.isEmpty then continue
@@ -616,7 +620,7 @@ private def handleClient (state : State) (client : Socket) : IO Unit := do
             match ← evalRequest state req with
             | none => pure ()
             | some response =>
-              let _ ← awaitTcp (← client.send #[(response.compress ++ "\n").toUTF8])
+              let _ ← liftM do awaitTcp (← client.send #[(response.compress ++ "\n").toUTF8])
 
 /-- Start the MCP server. Returns (port, shutdown action). -/
 def start (state : State) : IO (UInt16 × IO Unit) := do

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -440,7 +440,8 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         return toolContent
           "github.pat not set in config (required when target=upstream; pass target=\"fork\" to use the App token)"
           (isError := true)
-      logError s!"[mcp] tool create_pr [upstream]: {state.fork}:{head} -> {state.upstream} base={base} title={repr title}"
+      logError s!"[mcp] tool create_pr [upstream]: {state.fork}:{head} -> \
+        {state.upstream} base={base} title={repr title}"
       try
         let result ← createPullRequest state.pat state.upstream
           s!"{state.fork.owner}:{head}" base title body

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -11,7 +11,8 @@ open Lean (Json)
 open Std.Net
 open Std.Internal.UV.TCP
 open Orchestra (MonadLog MonadGitHubApp MonadGitHub MonadProjectTool MonadSubmitOutput
-  logError createJWT getInstallationId createInstallationToken setupGhAuth
+  MonadProject MonadClaim MonadTaskStore MonadQueue logError
+  createJWT getInstallationId createInstallationToken setupGhAuth
   createPullRequest createPullRequestOnRepo getPrReviewThreads createIssueComment
   replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber
   submitOutput)
@@ -94,8 +95,50 @@ instance : MonadGitHub DaemonM where
   createPrReview t r n b cs               := liftM (GitHub.createPrReview t r n b cs)
   getPrReviewCommentPrNumber t r n         := liftM (GitHub.getPrReviewCommentPrNumber t r n)
 
+instance : MonadTaskStore DaemonM where
+  saveTask r                  := liftM (TaskStore.saveTask r)
+  loadTask id                 := liftM (TaskStore.loadTask id)
+  loadAllTasks                := liftM TaskStore.loadAllTasks
+  latestInSeries s            := liftM (TaskStore.latestInSeries s)
+  updateSeriesPointer s tid   := liftM (TaskStore.updateSeriesPointer s tid)
+  generateTaskId              := liftM TaskStore.generateId
+  currentIso8601              := liftM TaskStore.currentIso8601
+
+instance : MonadQueue DaemonM where
+  saveEntry e     := liftM (Queue.saveEntry e)
+  loadEntry id    := liftM (Queue.loadEntry id)
+  loadAllEntries  := liftM Queue.loadAllEntries
+  nextPending     := liftM Queue.nextPending
+  writePid pid    := liftM (Queue.writePid pid)
+  readPid         := liftM Queue.readPid
+  deletePid       := liftM Queue.deletePid
+
+instance : MonadProject DaemonM where
+  freshProjectId          := liftM Project.freshProjectId
+  freshIssueId            := liftM Project.freshIssueId
+  saveProject p           := liftM (Project.saveProject p)
+  loadProject pid         := liftM (Project.loadProject pid)
+  loadAllProjects         := liftM Project.loadAllProjects
+  saveIssue i             := liftM (Project.saveIssue i)
+  loadIssue pid iid       := liftM (Project.loadIssue pid iid)
+  loadIssues pid          := liftM (Project.loadIssues pid)
+  findIssue iid           := liftM (Project.findIssue iid)
+  childrenOf pid iid      := liftM (Project.childrenOf pid iid)
+  rootIssues pid          := liftM (Project.rootIssues pid)
+  loadRole pid s          := liftM (Project.loadRole pid s)
+  loadAllRoles pid        := liftM (Project.loadAllRoles pid)
+  roleSearchPaths pid s   := liftM (Project.roleSearchPaths pid s)
+
+instance : MonadClaim DaemonM where
+  loadClaim pid iid                   := liftM (Project.loadClaim pid iid)
+  loadClaims pid                      := liftM (Project.loadClaims pid)
+  tryClaim mgr pid iid tid ag now ser := liftM (Project.tryClaim mgr pid iid tid ag now ser)
+  release mgr pid iid st now          := liftM (Project.release mgr pid iid st now)
+  updateClaimTaskId mgr pid iid tid   := liftM (Project.updateClaimTaskId mgr pid iid tid)
+  forceRelease mgr pid iid            := liftM (Project.forceRelease mgr pid iid)
+
 instance : MonadProjectTool DaemonM where
-  evalProjectTool env call := liftM (Project.Tools.evalProjectTool env call)
+  evalProjectTool env call := Project.Tools.evalProjectTool env call
 
 -- JSON-RPC helpers
 

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -415,7 +415,7 @@ def parseRequest (msg : Json) : Option Request :=
 -- Evaluation
 
 private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLift IO m] [MonadExceptOf IO.Error m] (state : State) (call : ToolCall) : m Json := do
+    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (call : ToolCall) : m Json := do
   match call with
   | .health =>
     logError "[mcp] tool health"
@@ -539,7 +539,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
     logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
     match state.outputRef with
     | some ref =>
-      liftM (ref.set (some value))
+      MonadLiftT.monadLift (m := IO) (ref.set (some value))
       return toolContent "output recorded"
     | none =>
       return toolContent "output submission not available for this task" (isError := true)
@@ -554,7 +554,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
       , issueId       := state.issueId
       , enqueueMerger   := state.enqueueMerger
       , enqueueReviewer := state.enqueueReviewer }
-    liftM (Project.Tools.evalProjectTool env call)
+    MonadLiftT.monadLift (m := IO) (Project.Tools.evalProjectTool env call)
   | .unknown name =>
     logError s!"[mcp] tool {name}: unknown"
     return toolContent s!"unknown tool: {name}" (isError := true)
@@ -564,7 +564,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
 private def evalRequest [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLift IO m] [MonadExceptOf IO.Error m] (state : State) (req : Request) : m (Option Json) := do
+    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (req : Request) : m (Option Json) := do
   match req with
   | .initialize id =>
     logError "[mcp] initialize"

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -5,23 +5,21 @@ import Orchestra.Config
 import Orchestra.GitHub
 import Orchestra.Monad
 import Orchestra.Project.Tools
+import Orchestra.Monad.SubmitOutput
 
 open Lean (Json)
 open Std.Net
 open Std.Internal.UV.TCP
-open Orchestra (MonadLog MonadGitHubApp MonadGitHub MonadProjectTool
+open Orchestra (MonadLog MonadGitHubApp MonadGitHub MonadProjectTool MonadSubmitOutput
   logError createJWT getInstallationId createInstallationToken setupGhAuth
   createPullRequest createPullRequestOnRepo getPrReviewThreads createIssueComment
-  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber)
+  replyToPrReviewComment createPrReviewComment createPrReview getPrReviewCommentPrNumber
+  submitOutput)
 
 namespace Orchestra.Server
 
-/-- Mutable state for the server, shared with request handlers.
-    Parameterised by the effect monad `m` so that the output-submission
-    callback can be stored as a plain `m`-action rather than a raw
-    `IO.Ref`, avoiding the need for a `MonadLiftT IO m` constraint in
-    the request evaluators. -/
-structure State (m : Type → Type) where
+/-- Immutable configuration for the server, shared with request handlers. -/
+structure State where
   upstream : Repository
   fork : Repository
   /-- Optional tools enabled for this run.
@@ -38,10 +36,6 @@ structure State (m : Type → Type) where
   outputType : ResultType := .unit
   /-- The task input serialized as JSON. `none` when `inputType = .unit`. -/
   inputJson : Option Json := none
-  /-- Action invoked when the agent calls `submit_task_output`.  The caller
-      wires this to whatever storage it needs (e.g. `fun j => ref.set (some j)`);
-      `none` when output submission is not available for this task. -/
-  submitOutput : Option (Json → m Unit) := none
   /-- Issue or PR number this task was launched from. Required for the `comment` tool. -/
   issueNumber : Option Nat := none
   /-- Claim manager handle. Required for `claim_issue` / `release_claim` /
@@ -57,13 +51,51 @@ structure State (m : Type → Type) where
   agentBackend : String := "unknown"
   /-- Series the task belongs to. Recorded with claims. -/
   series : Option String := none
-  /-- Hook that enqueues a merger task, set by the daemon. Plumbed by
-      `Project.Tools.Env` so `decide_issue approve` can request a merge. -/
-  enqueueMerger : Option (Project.ProjectId → Project.IssueId → Project.PRRef →
-                          IO String) := none
-  /-- Optional auto-reviewer hook (F1). Plumbed to `Project.Tools.Env.enqueueReviewer`. -/
-  enqueueReviewer : Option (Project.Project → Project.IssueId → Project.PRRef →
-                            Project.ReviewerTemplate → IO String) := none
+  /-- Whether `decide_issue approve` is permitted to enqueue a merger task. -/
+  canEnqueueMerger : Bool := false
+  /-- Whether `attach_pr` is permitted to enqueue an auto-reviewer task. -/
+  canEnqueueReviewer : Bool := false
+
+-- Daemon monad
+
+/-- Environment threaded through the daemon's request-handling monad.
+    Holds the output ref used by `MonadSubmitOutput`. -/
+structure DaemonEnv where
+  outputRef : IO.Ref (Option Json)
+
+/-- The concrete monad in which the MCP server handles requests.
+    Wraps `IO` in a reader so `MonadSubmitOutput` can write to the output ref
+    without storing a callback in `State`. -/
+abbrev DaemonM := ReaderT DaemonEnv IO
+
+instance : MonadSubmitOutput DaemonM where
+  submitOutput j := do (← read).outputRef.set (some j)
+
+instance : MonadLog DaemonM where
+  logInfo  msg := liftM (IO.println msg)
+  logError msg := liftM (show IO Unit from do
+    let stderr ← IO.getStderr
+    stderr.putStrLn msg
+    stderr.flush)
+
+instance : MonadGitHubApp DaemonM where
+  createJWT appId keyPath             := liftM (GitHub.createJWT appId keyPath)
+  getInstallationId jwt owner         := liftM (GitHub.getInstallationId jwt owner)
+  createInstallationToken jwt instId  := liftM (GitHub.createInstallationToken jwt instId)
+  setupGhAuth token                   := liftM (GitHub.setupGhAuth token)
+
+instance : MonadGitHub DaemonM where
+  createPullRequest t r ti b h bs          := liftM (GitHub.createPullRequest t r ti b h bs)
+  createPullRequestOnRepo t r ti b h bs    := liftM (GitHub.createPullRequestOnRepo t r ti b h bs)
+  getPrReviewThreads r n t                 := liftM (GitHub.getPrReviewThreads r n t)
+  createIssueComment t r n b               := liftM (GitHub.createIssueComment t r n b)
+  replyToPrReviewComment t r n c b         := liftM (GitHub.replyToPrReviewComment t r n c b)
+  createPrReviewComment t r n p f l b      := liftM (GitHub.createPrReviewComment t r n p f l b)
+  createPrReview t r n b cs               := liftM (GitHub.createPrReview t r n b cs)
+  getPrReviewCommentPrNumber t r n         := liftM (GitHub.getPrReviewCommentPrNumber t r n)
+
+instance : MonadProjectTool DaemonM where
+  evalProjectTool env call := liftM (Project.Tools.evalProjectTool env call)
 
 -- JSON-RPC helpers
 
@@ -257,7 +289,7 @@ Call this tool exactly once when the task is complete."),
       ]]
   inputTool ++ outputTool
 
-private def toolsList {m : Type → Type} (state : State m) : Json :=
+private def toolsList (state : State) : Json :=
   let optional := optionalToolDefs.filterMap fun entry =>
     if state.allowedTools.contains entry.1 then some entry.2 else none
   let project := Project.Tools.toolDefs.filterMap fun (perm, _name, def_) =>
@@ -421,7 +453,8 @@ def parseRequest (msg : Json) : Option Request :=
 -- Evaluation
 
 private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadProjectTool m] [MonadExceptOf IO.Error m] (state : State m) (call : ToolCall) : m Json := do
+    [MonadProjectTool m] [MonadExceptOf IO.Error m] [MonadSubmitOutput m]
+    (state : State) (call : ToolCall) : m Json := do
   match call with
   | .health =>
     logError "[mcp] tool health"
@@ -543,23 +576,19 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
     | none   => return toolContent "no input available" (isError := true)
   | .submitTaskOutput value =>
     logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
-    match state.submitOutput with
-    | some f =>
-      f value
-      return toolContent "output recorded"
-    | none =>
-      return toolContent "output submission not available for this task" (isError := true)
+    submitOutput value
+    return toolContent "output recorded"
   | .project call =>
     let env : Project.Tools.Env :=
-      { claimManager  := state.claimManager
-      , allowedTools  := state.allowedTools
-      , taskId        := state.taskId
-      , agentBackend  := state.agentBackend
-      , series        := state.series
-      , projectId     := state.projectId
-      , issueId       := state.issueId
-      , enqueueMerger   := state.enqueueMerger
-      , enqueueReviewer := state.enqueueReviewer }
+      { claimManager     := state.claimManager
+      , allowedTools     := state.allowedTools
+      , taskId           := state.taskId
+      , agentBackend     := state.agentBackend
+      , series           := state.series
+      , projectId        := state.projectId
+      , issueId          := state.issueId
+      , canEnqueueMerger   := state.canEnqueueMerger
+      , canEnqueueReviewer := state.canEnqueueReviewer }
     MonadProjectTool.evalProjectTool env call
   | .unknown name =>
     logError s!"[mcp] tool {name}: unknown"
@@ -570,7 +599,8 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
 private def evalRequest [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadProjectTool m] [MonadExceptOf IO.Error m] (state : State m) (req : Request) : m (Option Json) := do
+    [MonadProjectTool m] [MonadExceptOf IO.Error m] [MonadSubmitOutput m]
+    (state : State) (req : Request) : m (Option Json) := do
   match req with
   | .initialize id =>
     logError "[mcp] initialize"
@@ -602,7 +632,7 @@ Reads newline-delimited JSON messages, dispatches them, and writes responses.
 A line buffer handles the case where a single TCP receive spans multiple messages
 or a message is split across multiple receives.
 -/
-private def handleClient (state : State IO) (client : Socket) : IO Unit := do
+private def handleClient (state : State) (client : Socket) : DaemonM Unit := do
   let buf ← IO.mkRef ""
   repeat do
     let data? ← awaitTcp (← client.recv? 65536)
@@ -628,7 +658,8 @@ private def handleClient (state : State IO) (client : Socket) : IO Unit := do
               let _ ← awaitTcp (← client.send #[(response.compress ++ "\n").toUTF8])
 
 /-- Start the MCP server. Returns (port, shutdown action). -/
-def start (state : State IO) : IO (UInt16 × IO Unit) := do
+def start (state : State) (outputRef : IO.Ref (Option Json)) : IO (UInt16 × IO Unit) := do
+  let daemonEnv : DaemonEnv := { outputRef }
   let server ← Socket.new
   let addr := SocketAddress.v4 { addr := IPv4Addr.ofParts 127 0 0 1, port := 0 }
   server.bind addr
@@ -645,7 +676,7 @@ def start (state : State IO) : IO (UInt16 × IO Unit) := do
         if !(← running.get) then break
         let _ ← IO.asTask (prio := .dedicated) do
           logError "[mcp] client connected"
-          try handleClient state client
+          try (handleClient state client).run daemonEnv
           catch _ => pure ()
           logError "[mcp] client disconnected"
   let shutdown : IO Unit := do

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -415,7 +415,7 @@ def parseRequest (msg : Json) : Option Request :=
 -- Evaluation
 
 private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (call : ToolCall) : m Json := do
+    [MonadLift IO m] [MonadExceptOf IO.Error m] (state : State) (call : ToolCall) : m Json := do
   match call with
   | .health =>
     logError "[mcp] tool health"
@@ -539,7 +539,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
     logError s!"[mcp] tool submit_task_output: {value.compress.take 200}"
     match state.outputRef with
     | some ref =>
-      liftM (α := Unit) (m := IO) (ref.set (some value))
+      liftM (ref.set (some value))
       return toolContent "output recorded"
     | none =>
       return toolContent "output submission not available for this task" (isError := true)
@@ -564,7 +564,7 @@ private def evalToolCall [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub 
 
 /-- Evaluate a parsed JSON-RPC request. Returns `some` response, or `none` for notifications. -/
 private def evalRequest [Monad m] [MonadLog m] [MonadGitHubApp m] [MonadGitHub m]
-    [MonadLiftT IO m] [MonadExceptOf IO.Error m] (state : State) (req : Request) : m (Option Json) := do
+    [MonadLift IO m] [MonadExceptOf IO.Error m] (state : State) (req : Request) : m (Option Json) := do
   match req with
   | .initialize id =>
     logError "[mcp] initialize"

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -340,7 +340,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       Use 'tools' instead (e.g. {repr allowedTools}) and optionally 'read_only: true/false'."
   let inputJson := some (ResultType.valueToJson i input)
   let outputRef ← IO.mkRef (none : Option Lean.Json)
-  let serverState : Server.State := {
+  let serverState : Server.State IO := {
     upstream := ioTask.upstream
     fork := ioTask.fork
     allowedTools
@@ -351,7 +351,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     inputType := i
     outputType := o
     inputJson
-    outputRef := some outputRef
+    submitOutput := some (fun j => outputRef.set (some j))
     issueNumber := ioTask.issueNumber
     claimManager := some globalClaimManager
     taskId := some taskId

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -5,6 +5,7 @@ import Orchestra.Agents.Opencode
 import Orchestra.Agents.Pi
 import Orchestra.Agents.Vibe
 import Orchestra.GitHub
+import Orchestra.Monad
 import Orchestra.Repo
 import Orchestra.RepoConfig
 import Orchestra.Sandbox
@@ -25,25 +26,23 @@ initialize globalClaimManager : Project.ClaimManager ← Project.ClaimManager.ne
 
 /-- Enqueue a merger task for `pr` so the queue daemon will merge it later.
     Used by `decide_issue approve` via the `enqueueMerger` hook. Returns the
-    new queue entry's ID on success. -/
-def enqueueMergerImpl (pid : Project.ProjectId) (iid : Project.IssueId)
-    (pr : Project.PRRef) : IO (Except String String) := do
-  try
-    let id ← TaskStore.generateId
-    let createdAt ← TaskStore.currentIso8601
-    let entry : Queue.QueueEntry :=
-      { id, createdAt
-      , upstream := pr.repo, fork := pr.repo
-      , mode := .pr
-      , prompt := s!"merge {pr.repo}#{pr.number}"
-      , backend := some "merger"
-      , projectId := some pid
-      , issueId := some iid
-      , priority := 100 }
-    Queue.saveEntry entry
-    return .ok id
-  catch e =>
-    return .error (toString e)
+    new queue entry's ID. -/
+def enqueueMergerImpl [Monad m] [MonadTaskStore m] [MonadQueue m]
+    (pid : Project.ProjectId) (iid : Project.IssueId)
+    (pr : Project.PRRef) : m String := do
+  let id ← generateTaskId
+  let createdAt ← currentIso8601
+  let entry : Queue.QueueEntry :=
+    { id, createdAt
+    , upstream := pr.repo, fork := pr.repo
+    , mode := .pr
+    , prompt := s!"merge {pr.repo}#{pr.number}"
+    , backend := some "merger"
+    , projectId := some pid
+    , issueId := some iid
+    , priority := 100 }
+  saveEntry entry
+  return id
 
 /-- Render the reviewer prompt template with the PR / issue context. -/
 private def renderReviewerPrompt (tmpl : String) (pr : Project.PRRef) (iid : Project.IssueId)
@@ -55,28 +54,26 @@ private def renderReviewerPrompt (tmpl : String) (pr : Project.PRRef) (iid : Pro
 
 /-- Enqueue a reviewer task for `pr` against `tmpl`. Used by `attach_pr` via
     the `enqueueReviewer` hook when a project has a `reviewer` template. -/
-def enqueueReviewerImpl (project : Project.Project) (iid : Project.IssueId)
-    (pr : Project.PRRef) (tmpl : Project.ReviewerTemplate) : IO (Except String String) := do
-  try
-    let id ← TaskStore.generateId
-    let createdAt ← TaskStore.currentIso8601
-    let entry : Queue.QueueEntry :=
-      { id, createdAt
-      , upstream := pr.repo, fork := pr.repo
-      , mode := .pr
-      , prompt := renderReviewerPrompt tmpl.promptTemplate pr iid
-      , backend := tmpl.backend
-      , projectId := some project.id
-      , issueId := some iid
-      -- The reviewer needs review tools but should also be able to comment / read PRs.
-      , tools := some ["review_issues", "comment", "get_pr_comments"]
-      , readOnly := true
-      , issueNumber := some pr.number
-      , priority := 50 }
-    Queue.saveEntry entry
-    return .ok id
-  catch e =>
-    return .error (toString e)
+def enqueueReviewerImpl [Monad m] [MonadTaskStore m] [MonadQueue m]
+    (project : Project.Project) (iid : Project.IssueId)
+    (pr : Project.PRRef) (tmpl : Project.ReviewerTemplate) : m String := do
+  let id ← generateTaskId
+  let createdAt ← currentIso8601
+  let entry : Queue.QueueEntry :=
+    { id, createdAt
+    , upstream := pr.repo, fork := pr.repo
+    , mode := .pr
+    , prompt := renderReviewerPrompt tmpl.promptTemplate pr iid
+    , backend := tmpl.backend
+    , projectId := some project.id
+    , issueId := some iid
+    -- The reviewer needs review tools but should also be able to comment / read PRs.
+    , tools := some ["review_issues", "comment", "get_pr_comments"]
+    , readOnly := true
+    , issueNumber := some pr.number
+    , priority := 50 }
+  saveEntry entry
+  return id
 
 /-- Run a merger task: checkout the PR branch, run the validation script, then
     shell out to `gh pr merge`. If validation fails the issue is marked
@@ -84,7 +81,7 @@ def enqueueReviewerImpl (project : Project.Project) (iid : Project.IssueId)
     MCP path. Used when `ioTask.backend = some "merger"`. -/
 private def runMerger {i o : ResultType} (ioTask : IOTask i o)
     (repoPath : System.FilePath) (initialRecord : TaskStore.TaskRecord) : IO Unit := do
-  IO.println "  [merger] merge backend"
+  logInfo "  [merger] merge backend"
   let some pid := ioTask.projectId
     | throw (.userError "merger task missing project_id")
   let some iid := ioTask.issueId
@@ -95,7 +92,7 @@ private def runMerger {i o : ResultType} (ioTask : IOTask i o)
     | throw (.userError s!"merger: issue {iid.value} has no attached PRs")
   let prRef := s!"{pr.repo}#{pr.number}"
   -- Checkout the PR branch in the shared repo clone.
-  IO.println s!"  [merger] gh pr checkout {pr.number}"
+  logInfo s!"  [merger] gh pr checkout {pr.number}"
   let coChild ← IO.Process.spawn
     { cmd := "gh"
       args := #["pr", "checkout", toString pr.number, "--repo", pr.repo.toString]
@@ -106,22 +103,22 @@ private def runMerger {i o : ResultType} (ioTask : IOTask i o)
   let coStderr ← coChild.stderr.readToEnd
   let coExit ← coChild.wait
   if coExit != 0 then
-    IO.eprintln s!"  [merger] pr checkout failed:\n{coStderr}"
+    logError s!"  [merger] pr checkout failed:\n{coStderr}"
     throw (.userError "pr checkout failed")
   -- Run the validation script before merging.
-  IO.println "  [merger] running validation script"
+  logInfo "  [merger] running validation script"
   let (valid, validOutput) ← RepoConfig.runValidation repoPath
   if !validOutput.isEmpty then
-    IO.println s!"  [merger] validation output:\n{validOutput}"
+    logInfo s!"  [merger] validation output:\n{validOutput}"
   if !valid then
-    IO.eprintln s!"  [merger] validation failed for {prRef}, rejecting"
-    let now ← TaskStore.currentIso8601
+    logError s!"  [merger] validation failed for {prRef}, rejecting"
+    let now ← currentIso8601
     Project.saveIssue { issue with status := .rejected, updatedAt := now }
     let _ ← Project.forceRelease globalClaimManager pid iid
-    TaskStore.saveTask { initialRecord with status := .failed }
+    saveTask { initialRecord with status := .failed }
     throw (.userError s!"validation failed for {prRef}")
   -- Validation passed: merge the PR.
-  IO.println s!"  [merger] gh pr merge {prRef}"
+  logInfo s!"  [merger] gh pr merge {prRef}"
   let mergeChild ← IO.Process.spawn
     { cmd := "gh"
       args := #["pr", "merge", toString pr.number, "--repo", pr.repo.toString, "--squash", "--delete-branch"]
@@ -130,16 +127,16 @@ private def runMerger {i o : ResultType} (ioTask : IOTask i o)
   let mergeOut ← mergeChild.stdout.readToEnd
   let mergeErr ← mergeChild.stderr.readToEnd
   let mergeExit ← mergeChild.wait
-  let now ← TaskStore.currentIso8601
+  let now ← currentIso8601
   if mergeExit != 0 then
-    IO.eprintln s!"  [merger] gh pr merge failed (exit {mergeExit}):\n{mergeErr}"
+    logError s!"  [merger] gh pr merge failed (exit {mergeExit}):\n{mergeErr}"
     -- Leave the issue in .inReview so the reviewer can rerun the merger or re-decide.
-    TaskStore.saveTask { initialRecord with status := .failed }
+    saveTask { initialRecord with status := .failed }
     throw (.userError s!"gh pr merge {prRef} failed")
-  IO.println s!"  [merger] merged {prRef}\n{mergeOut}"
+  logInfo s!"  [merger] merged {prRef}\n{mergeOut}"
   Project.saveIssue { issue with status := .completed, updatedAt := now }
   let _ ← Project.forceRelease globalClaimManager pid iid
-  TaskStore.saveTask { initialRecord with status := .completed }
+  saveTask { initialRecord with status := .completed }
   -- If this issue has a parent that is blocked, check whether all siblings
   -- are now completed and unblock the parent if so.
   if let some parentId := issue.parentId then
@@ -147,9 +144,9 @@ private def runMerger {i o : ResultType} (ioTask : IOTask i o)
       if parent.status == .blocked then
         let siblings ← Project.childrenOf pid parentId
         if siblings.all (·.status == .completed) then
-          let now2 ← TaskStore.currentIso8601
+          let now2 ← currentIso8601
           Project.saveIssue { parent with status := .open, updatedAt := now2 }
-          IO.println s!"  [merger] all children of {parentId.value} completed; unblocked → open"
+          logInfo s!"  [merger] all children of {parentId.value} completed; unblocked → open"
 
 private def sanitizeProjectName (upstream : Repository) : String :=
   s!"{upstream.owner}-{upstream.name}"
@@ -229,7 +226,7 @@ def resolveAuthEnv (appConfig : AppConfig) (agentDef : AgentDef)
     -- Validate label uniqueness (warn on duplicates)
     let dupeCount := agentAuth.authSources.filter (fun s => s.label == label) |>.size
     if dupeCount > 1 then
-      IO.eprintln s!"  Warning: duplicate auth source label '{label}' for backend '{backendName}'"
+      logError s!"  Warning: duplicate auth source label '{label}' for backend '{backendName}'"
     -- Find the source with the matching label
     match agentAuth.authSources.find? (fun s => s.label == label) with
     | none => throw (.userError
@@ -248,15 +245,15 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     (cancelToken : Option Std.CancellationToken := none)
     (interactive : Bool := true)
     (interactiveAgent : Bool := false) : IO ((String × Bool) × Option o.Type × Option Lean.Json) := do
-  IO.println s!"=== Task {idx}: {ioTask.fork} ({repr ioTask.mode}) ==="
+  logInfo s!"=== Task {idx}: {ioTask.fork} ({repr ioTask.mode}) ==="
   -- Record this run in the task store
   -- TODO: unify queue entry IDs and task IDs. Currently the queue entry gets
   -- one ID at enqueue time and the task gets a second ID here at run time,
   -- requiring the pre-claim retag in `updateClaimTaskId`. The fix is to
   -- pre-assign the task ID on the queue entry and pass it in instead of
   -- generating a new one, making `entry.taskId : Option String` redundant.
-  let taskId ← TaskStore.generateId
-  let createdAt ← TaskStore.currentIso8601
+  let taskId ← generateTaskId
+  let createdAt ← currentIso8601
   let initialRecord : TaskStore.TaskRecord := {
     id := taskId, createdAt
     upstream := ioTask.upstream, fork := ioTask.fork, mode := ioTask.mode
@@ -268,7 +265,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     issueId   := ioTask.issueId
     role      := ioTask.role
   }
-  TaskStore.saveTask initialRecord
+  saveTask initialRecord
   -- If this task was pre-claimed (daemon wrote the claim with the queue-entry
   -- ID before we ran), retag the claim with the real generated taskId so that
   -- ownership checks in attach_pr / split_issue pass.
@@ -278,58 +275,58 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   let initialResume : Option String ← match continuesFrom with
     | none => pure none
     | some prevId =>
-      match ← TaskStore.loadTask prevId with
+      match ← loadTask prevId with
       | none =>
-        IO.eprintln s!"  Warning: task '{prevId}' not found, ignoring --continues"
+        logError s!"  Warning: task '{prevId}' not found, ignoring --continues"
         pure none
       | some prev => pure prev.sessionId
   -- Diagnostic block: surface the context the agent is starting with so the
   -- daemon log shows project/issue/series/resume info without having to grep
   -- the per-task .log file. Kept compact: prompt is dumped verbatim, but the
   -- prepend-prompt is shown by name only (its body is loaded later).
-  IO.println s!"  Task ID: {taskId}"
+  logInfo s!"  Task ID: {taskId}"
   match ioTask.projectId with
   | none     => pure ()
   | some pid =>
     match ← Project.loadProject pid with
-    | some pr => IO.println s!"  Project: {pid.value} ({pr.name})"
-    | none    => IO.println s!"  Project: {pid.value} (not found)"
+    | some pr => logInfo s!"  Project: {pid.value} ({pr.name})"
+    | none    => logInfo s!"  Project: {pid.value} (not found)"
   match ioTask.issueId, ioTask.projectId with
   | some iid, some pid =>
     match ← Project.loadIssue pid iid with
-    | some i => IO.println s!"  Issue:   {iid.value} ({i.title})"
-    | none   => IO.println s!"  Issue:   {iid.value} (not found)"
-  | some iid, none => IO.println s!"  Issue:   {iid.value}"
+    | some i => logInfo s!"  Issue:   {iid.value} ({i.title})"
+    | none   => logInfo s!"  Issue:   {iid.value} (not found)"
+  | some iid, none => logInfo s!"  Issue:   {iid.value}"
   | none,     _    => pure ()
   match continuesFrom, initialResume with
   | some prevId, some sid =>
-      IO.println s!"  Resuming task {prevId} (session {sid})"
+      logInfo s!"  Resuming task {prevId} (session {sid})"
   | some prevId, none =>
-      IO.println s!"  Resuming task {prevId} (no session id recorded)"
+      logInfo s!"  Resuming task {prevId} (no session id recorded)"
   | none,        _    => pure ()
   match series with
-  | some s => IO.println s!"  Series:  {s}"
+  | some s => logInfo s!"  Series:  {s}"
   | none   => pure ()
   match ioTask.prependPrompt with
-  | some name => IO.println s!"  Prepend prompt: {name}"
+  | some name => logInfo s!"  Prepend prompt: {name}"
   | none      => pure ()
-  IO.println "  Prompt:"
+  logInfo "  Prompt:"
   for line in ioTask.prompt.splitOn "\n" do
-    IO.println s!"    {line}"
+    logInfo s!"    {line}"
   -- 1. Create GitHub App token
-  IO.println "  Creating GitHub App token..."
-  let jwt ← GitHub.createJWT appConfig.appId appConfig.privateKeyPath
+  logInfo "  Creating GitHub App token..."
+  let jwt ← createJWT appConfig.appId appConfig.privateKeyPath
   let forkOwner := ioTask.fork.owner
   let installationId ← match appConfig.installationId with
     | some id => pure id
-    | none => GitHub.getInstallationId jwt forkOwner
-  let token ← GitHub.createInstallationToken jwt installationId
-  GitHub.setupGhAuth token
-  IO.println "  Token ready"
+    | none => getInstallationId jwt forkOwner
+  let token ← createInstallationToken jwt installationId
+  setupGhAuth token
+  logInfo "  Token ready"
   -- 2. Clone / update repo
-  IO.println s!"Cloning/updating {ioTask.fork}..."
+  logInfo s!"Cloning/updating {ioTask.fork}..."
   let repoPath ← Repo.ensureCloned ioTask.fork ioTask.upstream interactive
-  IO.println s!"  Repo at {repoPath}"
+  logInfo s!"  Repo at {repoPath}"
   -- Merger: checkout the PR branch, run validation, then merge. Shares auth +
   -- clone setup with all other backends but skips the MCP server and agent.
   if ioTask.backend == some "merger" then
@@ -339,7 +336,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   -- Resolve allowed tools: prefer explicit `tools` list, fall back to `mode` for backwards compat
   let (allowedTools, usingModeFallback) := resolveTools ioTask.mode ioTask.tools
   if usingModeFallback then
-    IO.eprintln s!"  Deprecation warning: the 'mode' field is deprecated. \
+    logError s!"  Deprecation warning: the 'mode' field is deprecated. \
       Use 'tools' instead (e.g. {repr allowedTools}) and optionally 'read_only: true/false'."
   let inputJson := some (ResultType.valueToJson i input)
   let outputRef ← IO.mkRef (none : Option Lean.Json)
@@ -366,12 +363,12 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     enqueueReviewer := some enqueueReviewerImpl
   }
   let (port, shutdown) ← Server.start serverState
-  IO.println s!"  MCP server on port {port}"
+  logInfo s!"  MCP server on port {port}"
   -- 4. Run init hook and load per-repository config
   RepoConfig.runInitIfNeeded repoPath
   let repoConfig ← RepoConfig.loadRepoConfig repoPath
   -- 5. Validation loop: before.sh → agent → validation.sh, retry on failure
-  let baseSystemPrompt ← loadSystemPrompt ioTask.systemPrompt
+  let baseSystemPrompt ← readSystemPrompt ioTask.systemPrompt
   -- 5a. Resolve memory directories and amend system prompt
   let memoryDirs ← resolveMemoryDirs ioTask.memory ioTask.upstream
   let systemPrompt :=
@@ -381,7 +378,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     | none,    some mp => some mp
     | some sp, some mp => some (sp ++ "\n\n" ++ mp)
   -- 5b. Load prepend prompt and apply to task prompt
-  let prependPrompt ← loadPrependPrompt ioTask.prependPrompt
+  let prependPrompt ← readPrependPrompt ioTask.prependPrompt
   let baseTaskPrompt :=
     match prependPrompt with
     | none    => ioTask.prompt
@@ -398,7 +395,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       if attempt == 0 then baseTaskPrompt
       else repoConfig.validation.retryPrompt.replace "{{validation_output}}" lastValidationOutput
     let resume := if attempt == 0 then initialResume else sessionId
-    IO.println s!"  Launching agent (attempt {attempt + 1}/{maxAttempts})..."
+    logInfo s!"  Launching agent (attempt {attempt + 1}/{maxAttempts})..."
     let agentDef := match ioTask.backend with
       | some "pi"       => AgentDef.pi
       | some "vibe"     => AgentDef.vibe
@@ -424,34 +421,34 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       (readOnly := ioTask.readOnly) (extraPorts := extraPorts)
       (additionalPaths := appConfig.additionalSandboxPaths)
       (interactiveAgent := interactiveAgent)
-    IO.println s!"  Agent exited with code {result.exitCode}"
+    logInfo s!"  Agent exited with code {result.exitCode}"
     sessionId := result.sessionId
     lastResultSubtype := result.resultSubtype
     if interactiveAgent then
       break
     if result.wasCancelled then
-      IO.println "  Agent was cancelled."
+      logInfo "  Agent was cancelled."
       wasCancelled := true
       break
     if result.usageLimitHit then
-      IO.println "  Agent hit usage limit."
+      logInfo "  Agent hit usage limit."
       usageLimitHit := true
       break
     if !(← RepoConfig.hasValidationScript repoPath) then
-      IO.println "  No validation script found, skipping validation."
+      logInfo "  No validation script found, skipping validation."
       break
-    IO.println "  Running validation script..."
+    logInfo "  Running validation script..."
     let (valid, validationOutput) ← RepoConfig.runValidation repoPath
     lastValidationOutput := validationOutput
     if !validationOutput.isEmpty then
-      IO.println s!"  Validation output:\n{validationOutput}"
+      logInfo s!"  Validation output:\n{validationOutput}"
     if valid then
-      IO.println "  Validation passed."
+      logInfo "  Validation passed."
       break
     if attempt + 1 < maxAttempts then
-      IO.println s!"  Validation failed, retrying ({attempt + 1}/{repoConfig.validation.maxRetries})..."
+      logInfo s!"  Validation failed, retrying ({attempt + 1}/{repoConfig.validation.maxRetries})..."
     else
-      IO.eprintln s!"  Validation still failing after {repoConfig.validation.maxRetries} retries"
+      logError s!"  Validation still failing after {repoConfig.validation.maxRetries} retries"
   -- 6. Run after hook and shut down MCP server
   RepoConfig.runHook repoPath "after.sh"
   shutdown
@@ -463,7 +460,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       | some .errorMaxBudgetUsd => .unfinished
       | some (.error _)         => .failed
       | _                       => if usageLimitHit then .unfinished else .completed
-  TaskStore.saveTask { initialRecord with sessionId, status := finalStatus }
+  saveTask { initialRecord with sessionId, status := finalStatus }
   -- Release the orchestra-issue claim on terminal status. If the worker
   -- already moved the issue to .inReview via attach_pr, leave that status
   -- alone and only delete the lock file (forceRelease). Otherwise hand the
@@ -472,7 +469,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   | some _pid, some iid =>
     match ← Project.findIssue iid with
     | some (project, issue) =>
-      let now ← TaskStore.currentIso8601
+      let now ← currentIso8601
       let succeeded := finalStatus matches .completed
       if succeeded && issue.status == .inReview then
         let _ ← Project.forceRelease globalClaimManager project.id iid
@@ -481,8 +478,8 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     | none => pure ()
   | _, _ => pure ()
   if let some seriesName := series then
-    TaskStore.updateSeriesPointer seriesName taskId
-  IO.println s!"=== Task {idx} done ===\n"
+    updateSeriesPointer seriesName taskId
+  logInfo s!"=== Task {idx} done ===\n"
   let outputJson ← outputRef.get
   let typedOutput : Option o.Type ← do
     match outputJson with
@@ -491,7 +488,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       match ResultType.valueFromJson o j with
       | .ok v    => pure (some v)
       | .error e =>
-        IO.eprintln s!"  Warning: failed to parse task output: {e}"
+        logError s!"  Warning: failed to parse task output: {e}"
         pure none
   return ((taskId, usageLimitHit), typedOutput, outputJson)
 

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -6,6 +6,7 @@ import Orchestra.Agents.Pi
 import Orchestra.Agents.Vibe
 import Orchestra.GitHub
 import Orchestra.Monad
+import Orchestra.Project.Enqueue
 import Orchestra.Repo
 import Orchestra.RepoConfig
 import Orchestra.Sandbox
@@ -24,56 +25,6 @@ namespace Orchestra.TaskRunner
     intra-process claim acquisition; on-disk files survive restarts. -/
 initialize globalClaimManager : Project.ClaimManager ← Project.ClaimManager.new
 
-/-- Enqueue a merger task for `pr` so the queue daemon will merge it later.
-    Used by `decide_issue approve` via the `enqueueMerger` hook. Returns the
-    new queue entry's ID. -/
-def enqueueMergerImpl [Monad m] [MonadTaskStore m] [MonadQueue m]
-    (pid : Project.ProjectId) (iid : Project.IssueId)
-    (pr : Project.PRRef) : m String := do
-  let id ← generateTaskId
-  let createdAt ← currentIso8601
-  let entry : Queue.QueueEntry :=
-    { id, createdAt
-    , upstream := pr.repo, fork := pr.repo
-    , mode := .pr
-    , prompt := s!"merge {pr.repo}#{pr.number}"
-    , backend := some "merger"
-    , projectId := some pid
-    , issueId := some iid
-    , priority := 100 }
-  saveEntry entry
-  return id
-
-/-- Render the reviewer prompt template with the PR / issue context. -/
-private def renderReviewerPrompt (tmpl : String) (pr : Project.PRRef) (iid : Project.IssueId)
-    : String :=
-  tmpl.replace "{{repo}}"      pr.repo.toString
-    |>.replace "{{pr_number}}" (toString pr.number)
-    |>.replace "{{branch}}"    pr.branch
-    |>.replace "{{issue_id}}"  iid.value
-
-/-- Enqueue a reviewer task for `pr` against `tmpl`. Used by `attach_pr` via
-    the `enqueueReviewer` hook when a project has a `reviewer` template. -/
-def enqueueReviewerImpl [Monad m] [MonadTaskStore m] [MonadQueue m]
-    (project : Project.Project) (iid : Project.IssueId)
-    (pr : Project.PRRef) (tmpl : Project.ReviewerTemplate) : m String := do
-  let id ← generateTaskId
-  let createdAt ← currentIso8601
-  let entry : Queue.QueueEntry :=
-    { id, createdAt
-    , upstream := pr.repo, fork := pr.repo
-    , mode := .pr
-    , prompt := renderReviewerPrompt tmpl.promptTemplate pr iid
-    , backend := tmpl.backend
-    , projectId := some project.id
-    , issueId := some iid
-    -- The reviewer needs review tools but should also be able to comment / read PRs.
-    , tools := some ["review_issues", "comment", "get_pr_comments"]
-    , readOnly := true
-    , issueNumber := some pr.number
-    , priority := 50 }
-  saveEntry entry
-  return id
 
 /-- Run a merger task: checkout the PR branch, run the validation script, then
     shell out to `gh pr merge`. If validation fails the issue is marked
@@ -265,12 +216,13 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     issueId   := ioTask.issueId
     role      := ioTask.role
   }
-  saveTask initialRecord
-  -- If this task was pre-claimed (daemon wrote the claim with the queue-entry
-  -- ID before we ran), retag the claim with the real generated taskId so that
-  -- ownership checks in attach_pr / split_issue pass.
-  if let (some pid, some iid) := (ioTask.projectId, ioTask.issueId) then
-    Project.updateClaimTaskId globalClaimManager pid iid taskId
+  if !interactiveAgent then
+    saveTask initialRecord
+    -- If this task was pre-claimed (daemon wrote the claim with the queue-entry
+    -- ID before we ran), retag the claim with the real generated taskId so that
+    -- ownership checks in attach_pr / split_issue pass.
+    if let (some pid, some iid) := (ioTask.projectId, ioTask.issueId) then
+      Project.updateClaimTaskId globalClaimManager pid iid taskId
   -- Resolve initial resume session from the continued task
   let initialResume : Option String ← match continuesFrom with
     | none => pure none
@@ -340,7 +292,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
       Use 'tools' instead (e.g. {repr allowedTools}) and optionally 'read_only: true/false'."
   let inputJson := some (ResultType.valueToJson i input)
   let outputRef ← IO.mkRef (none : Option Lean.Json)
-  let serverState : Server.State IO := {
+  let serverState : Server.State := {
     upstream := ioTask.upstream
     fork := ioTask.fork
     allowedTools
@@ -351,7 +303,6 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     inputType := i
     outputType := o
     inputJson
-    submitOutput := some (fun j => outputRef.set (some j))
     issueNumber := ioTask.issueNumber
     claimManager := some globalClaimManager
     taskId := some taskId
@@ -359,10 +310,10 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     series
     projectId := ioTask.projectId
     issueId   := ioTask.issueId
-    enqueueMerger   := some enqueueMergerImpl
-    enqueueReviewer := some enqueueReviewerImpl
+    canEnqueueMerger   := !interactiveAgent
+    canEnqueueReviewer := !interactiveAgent
   }
-  let (port, shutdown) ← Server.start serverState
+  let (port, shutdown) ← Server.start serverState outputRef
   logInfo s!"  MCP server on port {port}"
   -- 4. Run init hook and load per-repository config
   RepoConfig.runInitIfNeeded repoPath
@@ -388,9 +339,10 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   let mut wasCancelled := false
   let mut lastValidationOutput : String := ""
   let mut lastResultSubtype : Option StreamFormat.ResultSubtype := none
-  let maxAttempts := repoConfig.validation.maxRetries + 1
+  let maxAttempts := if interactiveAgent then 1 else repoConfig.validation.maxRetries + 1
   for attempt in List.range maxAttempts do
-    RepoConfig.runHook repoPath "before.sh"
+    if !interactiveAgent then
+      RepoConfig.runHook repoPath "before.sh"
     let prompt :=
       if attempt == 0 then baseTaskPrompt
       else repoConfig.validation.retryPrompt.replace "{{validation_output}}" lastValidationOutput
@@ -450,35 +402,37 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     else
       logError s!"  Validation still failing after {repoConfig.validation.maxRetries} retries"
   -- 6. Run after hook and shut down MCP server
-  RepoConfig.runHook repoPath "after.sh"
+  if !interactiveAgent then
+    RepoConfig.runHook repoPath "after.sh"
   shutdown
-  -- 7. Persist final task state
-  let finalStatus :=
-    if wasCancelled then .cancelled
-    else match lastResultSubtype with
-      | some .success           => .completed
-      | some .errorMaxBudgetUsd => .unfinished
-      | some (.error _)         => .failed
-      | _                       => if usageLimitHit then .unfinished else .completed
-  saveTask { initialRecord with sessionId, status := finalStatus }
-  -- Release the orchestra-issue claim on terminal status. If the worker
-  -- already moved the issue to .inReview via attach_pr, leave that status
-  -- alone and only delete the lock file (forceRelease). Otherwise hand the
-  -- issue back to the open pool so another worker can pick it up.
-  match ioTask.projectId, ioTask.issueId with
-  | some _pid, some iid =>
-    match ← Project.findIssue iid with
-    | some (project, issue) =>
-      let now ← currentIso8601
-      let succeeded := finalStatus matches .completed
-      if succeeded && issue.status == .inReview then
-        let _ ← Project.forceRelease globalClaimManager project.id iid
-      else
-        let _ ← Project.release globalClaimManager project.id iid .open now
-    | none => pure ()
-  | _, _ => pure ()
-  if let some seriesName := series then
-    updateSeriesPointer seriesName taskId
+  if !interactiveAgent then
+    -- 7. Persist final task state
+    let finalStatus :=
+      if wasCancelled then .cancelled
+      else match lastResultSubtype with
+        | some .success           => .completed
+        | some .errorMaxBudgetUsd => .unfinished
+        | some (.error _)         => .failed
+        | _                       => if usageLimitHit then .unfinished else .completed
+    saveTask { initialRecord with sessionId, status := finalStatus }
+    -- Release the orchestra-issue claim on terminal status. If the worker
+    -- already moved the issue to .inReview via attach_pr, leave that status
+    -- alone and only delete the lock file (forceRelease). Otherwise hand the
+    -- issue back to the open pool so another worker can pick it up.
+    match ioTask.projectId, ioTask.issueId with
+    | some _pid, some iid =>
+      match ← Project.findIssue iid with
+      | some (project, issue) =>
+        let now ← currentIso8601
+        let succeeded := finalStatus matches .completed
+        if succeeded && issue.status == .inReview then
+          let _ ← Project.forceRelease globalClaimManager project.id iid
+        else
+          let _ ← Project.release globalClaimManager project.id iid .open now
+      | none => pure ()
+    | _, _ => pure ()
+    if let some seriesName := series then
+      updateSeriesPointer seriesName taskId
   logInfo s!"=== Task {idx} done ===\n"
   let outputJson ← outputRef.get
   let typedOutput : Option o.Type ← do

--- a/OrchestraTest/ProjectToolsTest.lean
+++ b/OrchestraTest/ProjectToolsTest.lean
@@ -162,7 +162,7 @@ def decideApproveCallsHook : Test := do
       , taskId := some "T1"
       , agentBackend := "claude"
       , enqueueMerger := some (fun _ _ _ => do
-          calledRef.set true; return .ok "merger-task-id") }
+          calledRef.set true; return "merger-task-id") }
     let _ ← evalProjectTool env (.claimIssue issue.id)
     let _ ← evalProjectTool env
               (.attachPr issue.id { owner := "o", name := "r" } 9 "br")

--- a/OrchestraTest/ProjectToolsTest.lean
+++ b/OrchestraTest/ProjectToolsTest.lean
@@ -150,9 +150,8 @@ def decideRejectClearsClaim : Test := do
   TestM.assertEqual status (some .open) (msg := "rejected issue returns to open")
 
 @[test]
-def decideApproveCallsHook : Test := do
-  let (calledRef : IO.Ref Bool) ← IO.mkRef false
-  let (msgOk, wasCalled) ← (withTempHome do
+def decideApproveBlockedWithoutFlag : Test := do
+  let isError ← (withTempHome do
     let project ← setupProject
     let issue ← addOpenIssue project.id
     let mgr ← ClaimManager.new
@@ -161,15 +160,38 @@ def decideApproveCallsHook : Test := do
       , allowedTools := [workIssuesPerm, reviewIssuesPerm]
       , taskId := some "T1"
       , agentBackend := "claude"
-      , enqueueMerger := some (fun _ _ _ => do
-          calledRef.set true; return "merger-task-id") }
+      , canEnqueueMerger := false }
     let _ ← evalProjectTool env (.claimIssue issue.id)
     let _ ← evalProjectTool env
               (.attachPr issue.id { owner := "o", name := "r" } 9 "br")
     let r ← evalProjectTool env (.decideIssue issue.id .approve "lgtm")
-    return (jsonContains r "merger task merger-task-id", ← calledRef.get))
-  TestM.assert msgOk     "decide_issue approve should report enqueued merger"
-  TestM.assert wasCalled "enqueueMerger hook should have been invoked"
+    return jsonContains r "not available")
+  TestM.assert isError "decide_issue approve without canEnqueueMerger should return error"
+
+@[test]
+def decideApproveEnqueuesWhenAllowed : Test := do
+  -- Use a temp data dir so queue entries don't pollute the real data dir.
+  let tmpData : System.FilePath :=
+    System.FilePath.mk "/tmp" / s!"orchestra-enqueue-test-{← IO.monoNanosNow}"
+  IO.FS.createDirAll tmpData
+  Orchestra.Dirs.setDataDirOverride (some tmpData)
+  let msgOk ← try withTempHome do
+    let project ← setupProject
+    let issue ← addOpenIssue project.id
+    let mgr ← ClaimManager.new
+    let env : Env :=
+      { claimManager := some mgr
+      , allowedTools := [workIssuesPerm, reviewIssuesPerm]
+      , taskId := some "T1"
+      , agentBackend := "claude"
+      , canEnqueueMerger := true }
+    let _ ← evalProjectTool env (.claimIssue issue.id)
+    let _ ← evalProjectTool env
+              (.attachPr issue.id { owner := "o", name := "r" } 9 "br")
+    let r ← evalProjectTool env (.decideIssue issue.id .approve "lgtm")
+    return jsonContains r "merger task"
+  finally Orchestra.Dirs.setDataDirOverride none
+  TestM.assert msgOk "decide_issue approve with canEnqueueMerger should report enqueued merger"
 
 @[test]
 def attachPrRequiresOwnership : Test := do


### PR DESCRIPTION
Closes #88.

## Summary

Introduces `Orchestra/Monad/` with six typeclasses that abstract over the concrete `IO` operations used throughout the codebase:

| Typeclass | Abstracts |
|---|---|
| `MonadLog` | `logInfo` / `logError` (stdout / stderr) |
| `MonadConfig` | `readAppConfig` / `readSystemPrompt` / `readPrependPrompt` |
| `MonadGitHubApp` | GitHub App JWT creation and installation-token operations |
| `MonadGitHub` | GitHub API operations via PAT or installation token |
| `MonadTaskStore` | task-record persistence and series-pointer tracking |
| `MonadQueue` | queue-entry persistence and PID-file management |

Every typeclass ships with an `IO` instance that delegates to the existing concrete implementations, preserving all prior behaviour. The umbrella module `Orchestra/Monad.lean` re-exports all six and is added to the top-level `Orchestra` library.

## Design

- **`MonadGitHubApp`** covers operations that require the GitHub App private key (JWT creation, installation token generation).
- **`MonadGitHub`** covers PAT/token-based API calls (PR creation, comments, review threads).  The split mirrors the issue's request to differentiate "access to the PAT" from "access only to the app".
- All typeclasses live under the `Orchestra` namespace; methods are exported so callers don't need to prefix them.
- No existing behaviour is changed — all IO instances delegate directly to the concrete implementations.

## Test plan

- [ ] `lake build Orchestra` passes with all 257 jobs successful
- [ ] All existing functionality preserved (IO instances are transparent wrappers)
- [ ] New modules can be imported independently via `import Orchestra.Monad`