### PR TITLE
feat: separate secrets from config.json via secrets.json

### DIFF
--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -447,11 +447,46 @@ def loadJsonFile (α : Type) [FromJson α] (path : System.FilePath) : IO α := d
     | .error e => throw (.userError s!"{path}: {e}")
     | .ok v => return v
 
+/-- Load `secrets.json` from the config base directory.
+    Returns a list of `(key, value)` pairs for use in template substitution.
+    If the file does not exist the empty list is returned silently. -/
+def loadSecrets : IO (List (String × String)) := do
+  let path := (← Dirs.configBase) / "secrets.json"
+  if !(← path.pathExists) then return []
+  let contents ← IO.FS.readFile path
+  match Json.parse contents with
+  | .error e => throw (.userError s!"{path}: JSON parse error: {e}")
+  | .ok j =>
+    match j with
+    | .obj kvs =>
+      let pairs ← kvs.toList.mapM fun (k, v) => do
+        match v with
+        | .str s => return (k, s)
+        | _ => throw (.userError s!"{path}: secret '{k}' must be a string")
+      return pairs
+    | _ => throw (.userError s!"{path}: expected a JSON object")
+
+/-- Replace every `{{key}}` occurrence in `text` with the corresponding secret value. -/
+def applySecrets (secrets : List (String × String)) (text : String) : String :=
+  secrets.foldl (fun acc (k, v) => acc.replace ("{{" ++ k ++ "}}") v) text
+
+/-- Like `loadJsonFile` but substitutes `{{key}}` patterns from `secrets` before parsing. -/
+def loadJsonFileWithSecrets (α : Type) [FromJson α] (path : System.FilePath)
+    (secrets : List (String × String)) : IO α := do
+  let contents := applySecrets secrets (← IO.FS.readFile path)
+  match Json.parse contents with
+  | .error e => throw (.userError s!"{path}: JSON parse error: {e}")
+  | .ok j =>
+    match FromJson.fromJson? j with
+    | .error e => throw (.userError s!"{path}: {e}")
+    | .ok v => return v
+
 def loadAppConfig (path : Option System.FilePath := none) : IO AppConfig := do
   let configPath : System.FilePath ← match path with
     | some p => expandHome p.toString
     | none   => do pure ((← Dirs.configBase) / "config.json")
-  loadJsonFile AppConfig configPath
+  let secrets ← loadSecrets
+  loadJsonFileWithSecrets AppConfig configPath secrets
 
 def loadTaskFile (path : System.FilePath) : IO TaskFile :=
   loadJsonFile TaskFile path

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -277,7 +277,8 @@ def listenerStateDir : IO System.FilePath :=
 def loadListenerConfig (name : String) : IO (Option ListenerConfig) := do
   let path := (← listenersConfigDir) / s!"{name}.json"
   if !(← path.pathExists) then return none
-  let raw ← IO.FS.readFile path
+  let secrets ← loadSecrets
+  let raw := applySecrets secrets (← IO.FS.readFile path)
   match Json.parse raw with
   | .error _ => return none
   | .ok j    =>
@@ -289,13 +290,14 @@ def loadListenerConfig (name : String) : IO (Option ListenerConfig) := do
 def loadAllListenerConfigs : IO (Array ListenerConfig) := do
   let dir ← listenersConfigDir
   if !(← dir.pathExists) then return #[]
+  let secrets ← loadSecrets
   let entries ← System.FilePath.readDir dir
   let mut configs : Array ListenerConfig := #[]
   for entry in entries do
     let name := entry.fileName
     if !name.endsWith ".json" then continue
     -- skip the state subdirectory entry (it has no .json extension anyway)
-    let raw ← IO.FS.readFile entry.path
+    let raw := applySecrets secrets (← IO.FS.readFile entry.path)
     match Json.parse raw with
     | .error e => IO.eprintln s!"Warning: failed to parse listener config {name}: {e}"
     | .ok j    =>


### PR DESCRIPTION
Closes #96

## Summary

- Add `loadSecrets` in `Config.lean` that reads an optional `<config-base>/secrets.json` file — a flat JSON object mapping string keys to string values
- Add `applySecrets` that substitutes `{{key}}` patterns in raw text using the loaded secrets
- Add `loadJsonFileWithSecrets` that applies secrets substitution before JSON parsing
- Update `loadAppConfig` to load secrets and apply them to `config.json` before parsing
- Update `loadListenerConfig` and `loadAllListenerConfigs` in `Listener.lean` to apply secrets when loading listener JSON files

## How it works

Create `~/.config/orchestra/secrets.json` (not tracked in git) with a flat object:

```json
{
  "MY_TOKEN": "ghp_...",
  "API_KEY": "sk-..."
}
```

Then reference secrets in `config.json` or listener configs using `{{MY_TOKEN}}`:

```json
{
  "github": { "pat": "{{MY_TOKEN}}" },
  "anthropic_api_key": "{{API_KEY}}"
}
```

If `secrets.json` does not exist, loading proceeds as before with no error.

## Test plan

- [ ] Build compiles cleanly (`lake build`)
- [ ] Config loads normally when `secrets.json` is absent
- [ ] `{{key}}` placeholders in `config.json` are replaced when `secrets.json` is present
- [ ] `{{key}}` placeholders in listener configs are replaced when `secrets.json` is present
- [ ] Non-string values in `secrets.json` produce a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)