### PR TITLE
feat(queue): parallel execution with git worktree support

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -136,6 +136,17 @@ private def cleanupHandler (_ : Parsed) : IO UInt32 := do
   Repo.cleanup
   return (0 : UInt32)
 
+private def cleanupListHandler (_ : Parsed) : IO UInt32 := do
+  let clones ← Repo.listClones
+  if clones.isEmpty then
+    IO.println "No repository clones found."
+    return (0 : UInt32)
+  for (mainPath, worktrees) in clones do
+    IO.println s!"  {mainPath}"
+    for wt in worktrees do
+      IO.println s!"    worktree: {wt}"
+  return (0 : UInt32)
+
 private def tasksHandler (p : Parsed) : IO UInt32 := do
   let limit := p.flag? "limit" |>.map (·.as! Nat) |>.getD 20
   let records := (← TaskStore.loadAllTasks).toList.take limit
@@ -478,9 +489,11 @@ private def handleSocketRequest
   try conn.close catch _ => pure ()
 
 private def queueStartHandler (p : Parsed) : IO UInt32 := do
-  let configPath   := p.flag? "config" |>.map (·.as! String)
-  let debug        := p.hasFlag "debug"
-  let background   := p.hasFlag "background"
+  let configPath          := p.flag? "config" |>.map (·.as! String)
+  let debug               := p.hasFlag "debug"
+  let background          := p.hasFlag "background"
+  let parallelLimit       := max 1 (p.flag? "parallel"          |>.map (·.as! Nat) |>.getD 1)
+  let parallelLimitPerRepo := max 1 (p.flag? "parallel-per-repo" |>.map (·.as! Nat) |>.getD 1)
   -- Background mode: re-exec as a detached daemon and exit
   if background then
     if ← Queue.daemonRunning then
@@ -539,6 +552,10 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
   let nextTokenId ← IO.mkRef (0 : Nat)
   -- Mutex serialising the "find next pending + mark running" claim operation.
   let claimMutex ← Std.BaseMutex.new
+  -- Tracks number of currently running tasks per repo (fork key) and total.
+  -- Both are protected by claimMutex.
+  let activePerRepo ← IO.mkRef ({} : Std.HashMap String Nat)
+  let totalActive   ← IO.mkRef (0 : Nat)
   -- Concert manager: handles suspended concert fibers waiting for task results.
   let concertMgr ← ConcertManager.new
   -- Socket server: receives control requests (add_task, add_concert, cancel, shutdown).
@@ -556,16 +573,55 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
     catch _ => pure ()
   -- Helper: atomically claim the next pending entry, marking it as running.
   -- Serialised by claimMutex so that multiple workers cannot claim the same entry.
-  let claimNextEntry : IO (Option Queue.QueueEntry) := do
+  -- Returns (entry, needsWorktree): needsWorktree is true when the repo is already
+  -- in use by another parallel task and this task should run in a git worktree.
+  let claimNextEntry : IO (Option (Queue.QueueEntry × Bool)) := do
     claimMutex.lock
-    let entry ← Queue.nextPending
-    if let some e := entry then
-      Queue.saveEntry { e with status := .running }
+    let total ← totalActive.get
+    let result ←
+      if total >= parallelLimit then
+        pure none
+      else do
+        let repoMap ← activePerRepo.get
+        let entry ← Queue.nextPendingWithRepoLimits repoMap parallelLimitPerRepo
+        match entry with
+        | none => pure none
+        | some e =>
+          Queue.saveEntry { e with status := .running }
+          let repoCount := repoMap.getD e.fork.toString 0
+          activePerRepo.modify (fun m => m.insert e.fork.toString (repoCount + 1))
+          totalActive.modify (· + 1)
+          pure (some (e, decide (0 < repoCount)))
     claimMutex.unlock
-    return entry
+    return result
+  -- Helper: release parallel-tracking state for a completed entry.
+  let releaseEntry (entry : Queue.QueueEntry) : IO Unit := do
+    claimMutex.lock
+    let n := (← activePerRepo.get).getD entry.fork.toString 0
+    activePerRepo.modify (fun m => m.insert entry.fork.toString (if n > 0 then n - 1 else 0))
+    totalActive.modify (fun t => if t > 0 then t - 1 else 0)
+    claimMutex.unlock
   -- Helper: run one queue entry to completion and update its status.
   -- Also signals the ConcertManager if the entry belongs to a concert.
-  let runEntry (entry : Queue.QueueEntry) : IO Unit := do
+  -- needsWorktree: when true, create an isolated git worktree for this task
+  -- instead of using the shared main clone, to allow parallel work on the same repo.
+  let runEntry (entry : Queue.QueueEntry) (needsWorktree : Bool) : IO Unit := do
+    -- Create a worktree for parallel tasks on the same repo.
+    let wtPath : Option System.FilePath ←
+      if !needsWorktree then pure none
+      else
+        try some <$> Repo.ensureWorktree entry.fork entry.upstream entry.id
+        catch e =>
+          IO.eprintln s!"  Failed to create worktree for {entry.id}: {e}"
+          try Queue.saveEntry { entry with status := .failed } catch _ => pure ()
+          releaseEntry entry
+          return
+    -- Cleanup action: remove worktree and release parallel-tracking slot.
+    let doCleanup : IO Unit := do
+      if let some wt := wtPath then
+        let mainPath := (← Repo.workDir) / entry.fork.owner / entry.fork.name
+        try Repo.removeWorktree mainPath wt catch _ => pure ()
+      releaseEntry entry
     let taskToken ← Std.CancellationToken.new
     let tokenId ← nextTokenId.modifyGet (fun n => (n, n + 1))
     activeTaskTokens.atomically (·.modify (·.push (tokenId, taskToken)))
@@ -610,6 +666,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
       let (taskId, usageLimitHit, outputJson) ← TaskRunner.runTask cfg task 0 debug
         (continuesFrom := entry.continuesFrom) (series := entry.series)
         (cancelToken := some taskToken) (interactive := false)
+        (repoPathOverride := wtPath)
       removeToken
       -- The sandbox always cancels taskToken with `.custom "done"` on normal exit, so
       -- `isCancelled` is true for both normal completion and watcher-triggered cancellation.
@@ -629,6 +686,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         Queue.saveEntry { entry with status := .done, taskId := some taskId, outputJson }
         if let some key := entry.concertStepKey then
           ConcertManager.signal concertMgr key outputJson
+      doCleanup
     catch e =>
       removeToken
       let explicitlyCancelled := (← taskToken.getCancellationReason) == some .cancel
@@ -641,6 +699,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         try Queue.saveEntry { entry with status := .failed } catch _ => pure ()
         try releaseClaimOnError catch _ => pure ()
         ConcertManager.signal concertMgr (entry.concertStepKey.getD "") none
+      doCleanup
   -- Load listener configs and spawn one fiber per listener.
   let listenerConfigs ← Listener.loadAllListenerConfigs
   if !listenerConfigs.isEmpty then
@@ -764,13 +823,20 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
           Listener.saveListenerState lcfg.name newState
         catch e =>
           IO.eprintln s!"  Listener '{lcfg.name}' poll error: {e}"
-  -- Queue worker loop: claim and run entries one at a time.
-  -- To support parallel execution in the future, spawn multiple copies of this loop.
-  try
+  -- Queue worker loop: claim and run one entry at a time.
+  -- Spawning parallelLimit copies of this loop enables parallel execution.
+  let workerLoop : IO Unit := do
     while !(← shutdownToken.isCancelled) do
       match ← claimNextEntry with
-      | none       => IO.sleep 1000
-      | some entry => runEntry entry
+      | none              => IO.sleep 1000
+      | some (entry, wt)  => runEntry entry wt
+  -- Spawn additional workers beyond the first (which runs on the main thread below).
+  for _ in List.range (parallelLimit - 1) do
+    let _workerTask ← IO.asTask (prio := .dedicated) workerLoop
+  if parallelLimit > 1 then
+    IO.println s!"Queue daemon running with parallelLimit={parallelLimit}, parallelLimitPerRepo={parallelLimitPerRepo}"
+  try
+    workerLoop
   finally
     match ← socketServerRef.get with
     | some s => try s.close catch _ => pure ()
@@ -969,9 +1035,17 @@ private def prepareCmd : Cmd := `[Cli|
     "fork" : String; "Fork repository in 'owner/repo' format"
 ]
 
+private def cleanupListCmd : Cmd := `[Cli|
+  list VIA cleanupListHandler; ["0.1.0"]
+  "List all repository clones and their git worktrees."
+]
+
 private def cleanupCmd : Cmd := `[Cli|
   cleanup VIA cleanupHandler; ["0.1.0"]
-  "Remove all cloned repositories."
+  "Manage cloned repositories. Without a subcommand, removes all clones and worktrees."
+
+  SUBCOMMANDS:
+    cleanupListCmd
 ]
 
 private def tasksCmd : Cmd := `[Cli|
@@ -1039,12 +1113,14 @@ private def queueAddCmd : Cmd := `[Cli|
 
 private def queueStartCmd : Cmd := `[Cli|
   start VIA queueStartHandler; ["0.1.0"]
-  "Start the queue daemon. Polls for pending tasks and runs them serially."
+  "Start the queue daemon. Polls for pending tasks and runs them in parallel up to the configured limit."
 
   FLAGS:
     c, config : String; "Path to config file (default: ~/.config/orchestra/config.json)"
     d, debug; "Print the landrun command before executing it"
     b, background; "Run the daemon in the background, detached from the terminal"
+    parallel : Nat; "Maximum number of tasks to run in parallel (default: 1)"
+    "parallel-per-repo" : Nat; "Maximum parallel tasks per repository; additional copies use git worktrees (default: 1)"
 ]
 
 private def queueStatusCmd : Cmd := `[Cli|

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -281,6 +281,19 @@ def nextPending : IO (Option QueueEntry) := do
   let maxPriEntries := pending.filter (·.priority == maxPri)
   return (maxPriEntries.back? |>.filter (·.priority == maxPri))
 
+/-- Like `nextPending` but skips repos where the running count equals or exceeds `perRepoLimit`.
+    `activePerRepo` maps fork key (owner/name) → number of currently running tasks on that repo. -/
+def nextPendingWithRepoLimits (activePerRepo : Std.HashMap String Nat) (perRepoLimit : Nat)
+    : IO (Option QueueEntry) := do
+  let all ← loadAllEntries
+  let pending := all.filter (fun e =>
+    e.status == .pending &&
+    activePerRepo.getD e.fork.toString 0 < perRepoLimit)
+  if pending.isEmpty then return none
+  let maxPri := pending.foldl (·.max ·.priority) 0
+  let maxPriEntries := pending.filter (·.priority == maxPri)
+  return maxPriEntries.back?
+
 -- PID file management
 
 def writePid (pid : UInt32) : IO Unit := do

--- a/Orchestra/Repo.lean
+++ b/Orchestra/Repo.lean
@@ -116,7 +116,65 @@ def ensureCloned (fork upstream : Repository) (interactive : Bool := true) : IO 
   runGh' #["auth", "setup-git"] none
   return repoPath
 
-/-- Remove all cloned repositories. -/
+/-- Path for the main clone of a fork repository. -/
+def clonePath (fork : Repository) : IO System.FilePath := do
+  return (← workDir) / fork.owner / fork.name
+
+/-- Path for a git worktree tied to a specific queue entry. -/
+def worktreePath (fork : Repository) (entryId : String) : IO System.FilePath := do
+  return (← workDir) / fork.owner / s!"{fork.name}-wt-{entryId}"
+
+/-- Create a git worktree for a parallel agent task on the same repository.
+    Ensures the main clone exists and is up to date first, then adds a detached
+    worktree that shares the same git objects. Returns the worktree path. -/
+def ensureWorktree (fork upstream : Repository) (entryId : String) : IO System.FilePath := do
+  let mainPath ← ensureCloned fork upstream (interactive := false)
+  let wtPath ← worktreePath fork entryId
+  if ← wtPath.pathExists then
+    return wtPath
+  IO.println s!"  Creating worktree at {wtPath}..."
+  runGit' #["worktree", "add", "--detach", wtPath.toString] mainPath
+  return wtPath
+
+/-- Remove a git worktree after the task using it finishes. -/
+def removeWorktree (mainPath : System.FilePath) (wtPath : System.FilePath) : IO Unit := do
+  try
+    runGit' #["worktree", "remove", "--force", wtPath.toString] mainPath
+    IO.println s!"  Removed worktree {wtPath}"
+  catch e =>
+    IO.eprintln s!"  Warning: failed to remove worktree {wtPath}: {e}"
+    try IO.FS.removeDirAll wtPath catch _ => pure ()
+
+/-- Return true if `path` is a main git clone (`.git/` is a directory, not a file). -/
+private def isMainClone (path : System.FilePath) : IO Bool :=
+  (path / ".git" / "config").pathExists
+
+/-- List all main clones under the work directory, together with any git worktrees
+    each clone has registered. Returns an array of (mainClonePath, worktreePaths). -/
+def listClones : IO (Array (System.FilePath × Array System.FilePath)) := do
+  let base ← workDir
+  if !(← base.pathExists) then return #[]
+  let mut result : Array (System.FilePath × Array System.FilePath) := #[]
+  for ownerEntry in ← base.readDir do
+    let ownerPath := ownerEntry.path
+    if !(← ownerPath.pathExists) then continue
+    for repoEntry in ← ownerPath.readDir do
+      let repoPath := repoEntry.path
+      if !(← isMainClone repoPath) then continue
+      let worktrees ← try
+        let out ← runGit #["worktree", "list", "--porcelain"] repoPath
+        let paths := out.splitOn "\n" |>.filterMap fun l =>
+          if l.startsWith "worktree " then
+            let p := (l.drop "worktree ".length).toString
+            if p != repoPath.toString then some (System.FilePath.mk p)
+            else none
+          else none
+        pure paths.toArray
+      catch _ => pure #[]
+      result := result.push (repoPath, worktrees)
+  return result
+
+/-- Remove all cloned repositories and worktrees. -/
 def cleanup : IO Unit := do
   let base ← workDir
   if ← base.pathExists then

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -247,7 +247,9 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     (series : Option String := none)
     (cancelToken : Option Std.CancellationToken := none)
     (interactive : Bool := true)
-    (interactiveAgent : Bool := false) : IO ((String × Bool) × Option o.Type × Option Lean.Json) := do
+    (interactiveAgent : Bool := false)
+    -- When set, skip cloning and use this path (a git worktree) directly.
+    (repoPathOverride : Option System.FilePath := none) : IO ((String × Bool) × Option o.Type × Option Lean.Json) := do
   IO.println s!"=== Task {idx}: {ioTask.fork} ({repr ioTask.mode}) ==="
   -- Record this run in the task store
   -- TODO: unify queue entry IDs and task IDs. Currently the queue entry gets
@@ -326,10 +328,16 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   let token ← GitHub.createInstallationToken jwt installationId
   GitHub.setupGhAuth token
   IO.println "  Token ready"
-  -- 2. Clone / update repo
-  IO.println s!"Cloning/updating {ioTask.fork}..."
-  let repoPath ← Repo.ensureCloned ioTask.fork ioTask.upstream interactive
-  IO.println s!"  Repo at {repoPath}"
+  -- 2. Clone / update repo (or use the provided worktree path directly)
+  let repoPath ← match repoPathOverride with
+    | some p =>
+      IO.println s!"  Using worktree at {p}"
+      pure p
+    | none   =>
+      IO.println s!"Cloning/updating {ioTask.fork}..."
+      let p ← Repo.ensureCloned ioTask.fork ioTask.upstream interactive
+      IO.println s!"  Repo at {p}"
+      pure p
   -- Merger: checkout the PR branch, run validation, then merge. Shares auth +
   -- clone setup with all other backends but skips the MCP server and agent.
   if ioTask.backend == some "merger" then
@@ -502,10 +510,11 @@ def runTask (appConfig : AppConfig) (task : Task) (idx : Nat) (debug : Bool)
     (series : Option String := none)
     (cancelToken : Option Std.CancellationToken := none)
     (interactive : Bool := true)
-    (interactiveAgent : Bool := false) : IO (String × Bool × Option Lean.Json) := do
+    (interactiveAgent : Bool := false)
+    (repoPathOverride : Option System.FilePath := none) : IO (String × Bool × Option Lean.Json) := do
   let ((taskId, usageLimitHit), _, outputJson) ←
     runIOTask appConfig task.ioTask idx debug default
-      continuesFrom series cancelToken interactive interactiveAgent
+      continuesFrom series cancelToken interactive interactiveAgent repoPathOverride
   return (taskId, usageLimitHit, outputJson)
 
 end Orchestra.TaskRunner


### PR DESCRIPTION
## Summary

Implements [#7](https://github.com/chrisflav/orchestra/issues/7) — parallel queue mode with git worktree support.

- **`--parallel N`** flag on `orchestra queue start`: run up to N tasks concurrently (default: 1, preserving existing serial behaviour)
- **`--parallel-per-repo N`** flag: cap concurrent tasks on the same repository (default: 1); when a second task targets the same repo it gets an isolated `git worktree` copy instead of the shared main clone
- **`orchestra cleanup list`** subcommand: list all main clones and their associated worktrees

## Implementation details

**`Orchestra/Queue.lean`** — `nextPendingWithRepoLimits`: variant of `nextPending` that skips repos whose running count is at the per-repo limit, using an in-memory `Std.HashMap String Nat` passed in from the daemon.

**`Orchestra/Repo.lean`** — three new functions:
- `ensureWorktree fork upstream entryId`: ensures the main clone exists, then runs `git worktree add --detach` to create an isolated working tree at `repos/<owner>/<name>-wt-<entryId>/`
- `removeWorktree mainPath wtPath`: runs `git worktree remove --force`, falls back to `IO.FS.removeDirAll` on failure
- `listClones`: walks the repos directory and returns `(mainClonePath, worktreePaths)` pairs by inspecting `.git/config` presence and `git worktree list --porcelain` output

**`Orchestra/TaskRunner.lean`** — `repoPathOverride : Option System.FilePath` added to `runIOTask` / `runTask`; when set the clone step is skipped and the given path (a worktree) is used directly.

**`Main.lean`**:
- `activePerRepo : IO.Ref (Std.HashMap String Nat)` and `totalActive : IO.Ref Nat` track in-flight tasks, both protected by the existing `claimMutex`
- `claimNextEntry` now returns `(entry, needsWorktree : Bool)` and enforces both limits
- `releaseEntry` decrements both counters when a task completes
- `runEntry` creates the worktree before execution and calls cleanup (worktree removal + `releaseEntry`) at the end of both the success and the error path
- N−1 extra worker `IO.asTask` tasks are spawned when `--parallel > 1`; the main thread acts as the Nth worker

## Test plan

- [ ] Default (no flags): serial behaviour unchanged — single task runs at a time
- [ ] `--parallel 3`: three tasks claimed and run simultaneously; daemon log shows all three active
- [ ] `--parallel 2 --parallel-per-repo 1`: two tasks run in parallel on *different* repos; a second task for the *same* repo stays pending until the first finishes
- [ ] `--parallel 2 --parallel-per-repo 2`: two tasks on the same repo run in parallel; worktree created at `repos/owner/name-wt-<id>/` and removed after task completes
- [ ] `orchestra cleanup list`: lists main clones and any live worktrees
- [ ] `orchestra cleanup`: still removes everything (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)