### PR TITLE
feat(listener): add github-label-count source type

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -662,6 +662,11 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
           let events ← Listener.pollSource liveCfg.source state appConfig.pat
             appConfig.authorizedUsers
           for (_, vars) in (events : Array (String × List (String × String))) do
+            -- github-label-count: skip if a task from this listener is already active.
+            if let .githubLabelCount .. := liveCfg.source then
+              if ← Queue.hasActiveEntryForListener lcfg.name then
+                IO.println s!"  Listener '{lcfg.name}': skipping (active entry already in queue)"
+                continue
             -- Project-dispatcher source: synthetic events carry only `role_name`
             -- and (optionally) `issue_id`. Build the queue entry directly from
             -- the named role template, pre-claiming through the in-process
@@ -750,7 +755,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
                 IO.eprintln s!"  Listener '{liveCfg.name}': failed to load workflow: {e}"
             else
               -- Single-task mode: enqueue a QueueEntry as before.
-              let qentry ← Listener.buildQueueEntry liveCfg.action vars
+              let qentry ← Listener.buildQueueEntry liveCfg.action vars (some lcfg.name)
               Queue.saveEntry qentry
               IO.println s!"  Listener '{liveCfg.name}': queued entry {qentry.id}"
           let newIds := events.filterMap (fun ev =>

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -50,6 +50,13 @@ inductive SourceConfig where
       Each tick the dispatcher counts active per-role queue entries and emits
       a synthetic event per role that is below its cap and whose trigger holds. -/
   | projectDispatcher (projectId : Project.ProjectId) (caps : List (String × Nat))
+  /-- Fires whenever the number of open issues or pull requests with the given
+      labels on a repository is strictly below `max`.  Emits one event per repo
+      per tick while the condition holds (no state deduplication — use a high
+      `interval_seconds` to avoid flooding the queue).
+      `kind` controls what is counted: `"issues"` (default), `"pulls"`, or `"all"`.
+      Template variables: `count`, `max`, `needed` (= max − count), `upstream`, `fork`. -/
+  | githubLabelCount  (repos : List RepoEntry) (labels : List String) (max : Nat) (kind : String)
 
 instance : ToJson SourceConfig where
   toJson
@@ -79,6 +86,12 @@ instance : ToJson SourceConfig where
                     ("project_id", Json.str pid.value),
                     ("caps", Json.mkObj
                        (caps.map (fun (n, c) => (n, Json.num c))))]
+    | .githubLabelCount repos labels max kind =>
+        Json.mkObj [("type", "github-label-count"),
+                    ("repos", ToJson.toJson repos),
+                    ("labels", ToJson.toJson labels),
+                    ("max", Json.num max),
+                    ("kind", kind)]
 
 /-- Parse a `repos` list from JSON.  If `"repos"` is absent, fall back to the singular
     `"fork"` string (treated as both `upstream` and `fork`). -/
@@ -123,6 +136,12 @@ instance : FromJson SourceConfig where
         let caps : List (String × Nat) := pairs.filterMap fun (k, v) =>
           v.getNat?.toOption.map (k, ·)
         return .projectDispatcher ⟨pid⟩ caps
+    | "github-label-count" =>
+        let repos  ← parseRepos j
+        let labels  := j.getObjValAs? (List String) "labels" |>.toOption |>.getD []
+        let max    ← j.getObjValAs? Nat "max"
+        let kind    := j.getObjValAs? String "kind" |>.toOption |>.getD "issues"
+        return .githubLabelCount repos labels max kind
     | _ => .error s!"unknown source type: {ty}"
 
 -- Action template
@@ -762,5 +781,34 @@ def pollSource (source : SourceConfig) (state : ListenerState) (ghToken : String
         | some iid => baseVars ++ [("issue_id", iid.value)]
         | none     => baseVars
       ("", vars)
+
+  | .githubLabelCount repos labels max kind => do
+    let mut allEvents : Array (String × List (String × String)) := #[]
+    for entry in repos do
+      let labelParam := if labels.isEmpty then "" else "&labels=" ++ ",".intercalate labels
+      let endpoint := s!"/repos/{entry.upstream}/issues?state=open&per_page=100{labelParam}"
+      let jsonOpt ← runGhApi endpoint ghToken
+      let items ← match jsonOpt with
+        | none   => pure (#[] : Array Json)
+        | some j => match j.getArr? with
+          | .ok a  => pure a
+          | .error _ => pure #[]
+      -- Count items matching the configured kind.
+      let shouldCount (item : Json) : Bool :=
+        let isPr := (item.getObjVal? "pull_request").isOk
+        match kind with
+        | "issues" => !isPr
+        | "pulls"  => isPr
+        | _        => true  -- "all" or unrecognised
+      let count := (items.filter shouldCount).size
+      if count < max then
+        let needed := max - count
+        let vars := [("count", toString count), ("max", toString max),
+                     ("needed", toString needed),
+                     ("upstream", entry.upstream.toString), ("fork", entry.fork.toString),
+                     ("upstream_escaped", entry.upstream.toString.replace "/" "_"),
+                     ("fork_escaped",     entry.fork.toString.replace "/" "_")]
+        allEvents := allEvents.push ("", vars)
+    return allEvents
 
 end Orchestra.Listener

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -51,9 +51,9 @@ inductive SourceConfig where
       a synthetic event per role that is below its cap and whose trigger holds. -/
   | projectDispatcher (projectId : Project.ProjectId) (caps : List (String × Nat))
   /-- Fires whenever the number of open issues or pull requests with the given
-      labels on a repository is strictly below `max`.  Emits one event per repo
-      per tick while the condition holds (no state deduplication — use a high
-      `interval_seconds` to avoid flooding the queue).
+      labels on a repository is strictly below `max`.  Emits at most one task per
+      tick; the tick is skipped while a task from this listener is already pending
+      or running.
       `kind` controls what is counted: `"issues"` (default), `"pulls"`, or `"all"`.
       Template variables: `count`, `max`, `needed` (= max − count), `upstream`, `fork`. -/
   | githubLabelCount  (repos : List RepoEntry) (labels : List String) (max : Nat) (kind : String)
@@ -356,7 +356,8 @@ def renderTemplate (template : String) (vars : List (String × String)) : String
 
 -- Queue entry builder
 
-def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : IO Queue.QueueEntry := do
+def buildQueueEntry (action : ActionConfig) (vars : List (String × String))
+    (listenerName : Option String := none) : IO Queue.QueueEntry := do
   let id        ← TaskStore.generateId
   let createdAt ← TaskStore.currentIso8601
   let prompt    := renderTemplate action.promptTemplate vars
@@ -399,6 +400,7 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
     priority     := action.priority
     issueNumber
     prLabels     := action.prLabels
+    listenerName
   }
 
 -- GitHub helpers

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -141,6 +141,8 @@ structure QueueEntry where
   role : Option String := none
   /-- Labels to apply automatically to every PR created via `create_pr`. -/
   prLabels : List String := []
+  /-- Name of the listener that created this entry, if any. -/
+  listenerName : Option String := none
 
 instance : ToJson QueueEntry where
   toJson e :=
@@ -177,8 +179,9 @@ instance : ToJson QueueEntry where
     let fields := if let some n := e.issueNumber then fields ++ [("issue_number", Json.num n)] else fields
     let fields := if let some p := e.projectId then fields ++ [("project_id", ToJson.toJson p)] else fields
     let fields := if let some i := e.issueId   then fields ++ [("issue_id",   ToJson.toJson i)] else fields
-    let fields := if let some r := e.role      then fields ++ [("role",       Json.str r)]      else fields
-    let fields := if !e.prLabels.isEmpty       then fields ++ [("pr_labels",  ToJson.toJson e.prLabels)] else fields
+    let fields := if let some r := e.role         then fields ++ [("role",          Json.str r)]      else fields
+    let fields := if !e.prLabels.isEmpty          then fields ++ [("pr_labels",     ToJson.toJson e.prLabels)] else fields
+    let fields := if let some s := e.listenerName then fields ++ [("listener_name", Json.str s)]      else fields
     Json.mkObj fields
 
 instance : FromJson QueueEntry where
@@ -214,13 +217,14 @@ instance : FromJson QueueEntry where
     let issueNumber := j.getObjValAs? Nat "issue_number" |>.toOption
     let projectId   := j.getObjValAs? ProjectId "project_id" |>.toOption
     let issueId     := j.getObjValAs? IssueId   "issue_id"   |>.toOption
-    let role        := j.getObjValAs? String    "role"       |>.toOption
-    let prLabels    := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
+    let role         := j.getObjValAs? String    "role"          |>.toOption
+    let prLabels     := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
+    let listenerName := j.getObjValAs? String "listener_name"    |>.toOption
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, prependPrompt, backend, model, continuesFrom, series, taskId, configPath,
              budget, memory, authSource, tools, readOnly, priority,
              concertStepKey, concertId, inputType, outputType, inputJson, outputJson,
-             issueNumber, projectId, issueId, role, prLabels }
+             issueNumber, projectId, issueId, role, prLabels, listenerName }
 
 -- Directories and paths
 
@@ -284,6 +288,12 @@ def nextPending : IO (Option QueueEntry) := do
   -- Among entries with max priority, pick the oldest (last in newest-first array)
   let maxPriEntries := pending.filter (·.priority == maxPri)
   return (maxPriEntries.back? |>.filter (·.priority == maxPri))
+
+/-- Return true if any entry created by `name` is currently pending or running. -/
+def hasActiveEntryForListener (name : String) : IO Bool := do
+  let entries ← loadAllEntries
+  return entries.any fun e =>
+    (e.status == .pending || e.status == .running) && e.listenerName == some name
 
 -- PID file management
 

--- a/OrchestraTest/ListenerConfigTest.lean
+++ b/OrchestraTest/ListenerConfigTest.lean
@@ -181,3 +181,56 @@ def agentAuthConfigExtraPortsDefault : Test := do
   | .error e => TestM.fail s!"AgentAuthConfig no extra_ports: {e}"
   | .ok cfg =>
     TestM.assertEqual cfg.extraPorts (#[] : Array Nat) (msg := "extraPorts default empty")
+
+@[test]
+def githubLabelCountBasic : Test := do
+  let json := r#"
+    {"type": "github-label-count",
+     "repos": [{"upstream": "org/repo", "fork": "my-org/fork"}],
+     "labels": ["needs-review"],
+     "max": 5}
+  "#
+  match Json.parse json >>= FromJson.fromJson? (α := SourceConfig) with
+  | .error e => TestM.fail s!"github-label-count parse: {e}"
+  | .ok (.githubLabelCount repos labels max kind) =>
+    TestM.assertEqual repos.length 1 (msg := "repos length")
+    TestM.assertEqual labels ["needs-review"] (msg := "labels")
+    TestM.assertEqual max 5 (msg := "max")
+    TestM.assertEqual kind "issues" (msg := "kind default")
+    match repos with
+    | [r] =>
+      TestM.assertEqual r.upstream.toString "org/repo" (msg := "upstream")
+      TestM.assertEqual r.fork.toString "my-org/fork" (msg := "fork")
+    | _ => TestM.fail "repos not a singleton"
+  | .ok _ => TestM.fail "unexpected SourceConfig variant"
+
+@[test]
+def githubLabelCountKindPulls : Test := do
+  let json := r#"
+    {"type": "github-label-count",
+     "repos": [{"upstream": "org/repo", "fork": "my-org/fork"}],
+     "labels": ["ready-for-review"],
+     "max": 3,
+     "kind": "pulls"}
+  "#
+  match Json.parse json >>= FromJson.fromJson? (α := SourceConfig) with
+  | .error e => TestM.fail s!"github-label-count pulls parse: {e}"
+  | .ok (.githubLabelCount _repos _labels max kind) =>
+    TestM.assertEqual max 3 (msg := "max")
+    TestM.assertEqual kind "pulls" (msg := "kind")
+  | .ok _ => TestM.fail "unexpected SourceConfig variant"
+
+@[test]
+def githubLabelCountRoundTrip : Test := do
+  let sc : SourceConfig := .githubLabelCount
+    [{ upstream := { owner := "org", name := "repo" }
+       fork := { owner := "my-org", name := "repo" } }]
+    ["bug", "help-wanted"] 10 "all"
+  match FromJson.fromJson? (ToJson.toJson sc) (α := SourceConfig) with
+  | .error e => TestM.fail s!"github-label-count round-trip: {e}"
+  | .ok (.githubLabelCount repos labels max kind) =>
+    TestM.assertEqual repos.length 1 (msg := "repos length")
+    TestM.assertEqual labels ["bug", "help-wanted"] (msg := "labels")
+    TestM.assertEqual max 10 (msg := "max")
+    TestM.assertEqual kind "all" (msg := "kind")
+  | .ok _ => TestM.fail "wrong variant"


### PR DESCRIPTION
Implements #104: adds a new `github-label-count` listener source that fires whenever the number of open issues or pull requests with given labels on a repository drops below a configured maximum.

- New `githubLabelCount` variant in `SourceConfig` with fields: `repos`, `labels`, `max`, `kind` (`"issues"` default, `"pulls"`, or `"all"`)
- Emits one event per repo per tick while `count < max` (no state deduplication — use a high `interval_seconds`)
- Template variables available to the action: `count`, `max`, `needed` (= max − count), `upstream`, `fork`, `upstream_escaped`, `fork_escaped`
- Round-trip JSON serialization via `ToJson`/`FromJson`
- Tests covering basic parse, `kind: "pulls"`, and round-trip

**Example listener config:**
```json
{
  "name": "maintain-review-queue",
  "source": {
    "type": "github-label-count",
    "repos": [{"upstream": "org/repo", "fork": "my-org/repo"}],
    "labels": ["needs-review"],
    "max": 5,
    "kind": "pulls"
  },
  "action": {
    "mode": "pr",
    "prompt_template": "There are {{count}} PRs with 'needs-review' but we want {{max}}. Please triage and label a PR."
  },
  "interval_seconds": 300
}
```
