### PR TITLE
feat(create_pr): auto-apply configured labels to created pull requests

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -593,6 +593,7 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         projectId        := entry.projectId
         issueId          := entry.issueId
         role             := entry.role
+        prLabels         := entry.prLabels
       }
     }
     let cfg ← match entry.configPath with

--- a/Orchestra/Concert/Json.lean
+++ b/Orchestra/Concert/Json.lean
@@ -28,6 +28,7 @@ instance {i o : ResultType} : ToJson (IOTask i o) where
     , ("tools",         ToJson.toJson t.tools)
     , ("read_only",     .bool t.readOnly)
     , ("series",        ToJson.toJson t.series)
+    , ("pr_labels",     ToJson.toJson t.prLabels)
     , ("input_type",    ToJson.toJson i)
     , ("output_type",   ToJson.toJson o)
     ]
@@ -48,8 +49,9 @@ instance {i o : ResultType} : FromJson (IOTask i o) where
     let tools        := j.getObjValAs? (List String) "tools" |>.toOption
     let readOnly     := j.getObjValAs? Bool "read_only" |>.toOption |>.getD false
     let series       := j.getObjValAs? String "series" |>.toOption
+    let prLabels     := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
     return { upstream, fork, mode, prompt, agent, systemPrompt, backend, model,
-             budget, memory, authSource, tools, readOnly, series }
+             budget, memory, authSource, tools, readOnly, series, prLabels }
 
 /-- Serialize a `Concert α` to JSON.
     For `run` nodes, the task spec is computed from the current input and the continuation is

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -245,6 +245,9 @@ structure IOTask (i o : ResultType) where
       by the project-dispatcher to count active per-role tasks unambiguously,
       avoiding fragile `tools` list comparisons. -/
   role : Option String := none
+  /-- Labels to automatically apply to every pull request created by `create_pr` during this task.
+      Labels that do not exist on the target repository are created automatically. -/
+  prLabels : List String := []
 deriving Repr, Inhabited
 
 /-- The kind of authentication for an agent backend. -/
@@ -344,9 +347,10 @@ instance : FromJson Task where
     let projectId   := j.getObjValAs? ProjectId "project_id" |>.toOption
     let issueId     := j.getObjValAs? IssueId   "issue_id"   |>.toOption
     let role        := j.getObjValAs? String    "role"       |>.toOption
+    let prLabels    := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
     return { i, o, ioTask := { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model,
                                 budget, memory, authSource, tools, readOnly, series, priority,
-                                issueNumber, projectId, issueId, role } }
+                                issueNumber, projectId, issueId, role, prLabels } }
 
 /-- Filesystem paths to expose inside the landrun sandbox. -/
 structure SandboxPaths where

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -101,32 +101,48 @@ def createInstallationToken (jwt : String) (installationId : Nat) : IO String :=
 def setupGhAuth (token : String) : IO Unit := do
   runCmd' "sh" #["-c", s!"echo '{token}' | gh auth login --with-token"]
 
+/-- Ensure the given labels exist on a repository.
+    Labels that are missing are created with a default colour; existing ones are not modified. -/
+def ensureLabels (token : String) (repo : Repository) (labels : List String) : IO Unit := do
+  let env := if token.isEmpty then #[] else #[("GH_TOKEN", some token)]
+  for label in labels do
+    try
+      let _ ← runCmd "gh" #["label", "create", label, "--repo", repo.toString, "--color", "0075ca"]
+        (env := env)
+    catch _ => pure ()
+
 /-- Create a pull request on the upstream repo using a PAT. -/
 def createPullRequest (pat : String) (upstream : Repository)
-    (head base title body : String) : IO String := do
-  runCmd "gh" #[
+    (head base title body : String) (labels : List String := []) : IO String := do
+  unless labels.isEmpty do
+    ensureLabels pat upstream labels
+  let labelArgs : Array String := (labels.flatMap fun l => ["--label", l]).toArray
+  runCmd "gh" (#[
     "pr", "create",
     "--repo", upstream.toString,
     "--head", head,
     "--base", base,
     "--title", title,
     "--body", body
-  ] (env := #[("GH_TOKEN", some pat)])
+  ] ++ labelArgs) (env := #[("GH_TOKEN", some pat)])
 
 /-- Create a pull request entirely within a single repository (no cross-repo
     `owner:branch` head prefix), authenticated by `token` — typically a fresh
     GitHub App installation token. Used when the agent wants to open a PR on
     its fork rather than the upstream. -/
 def createPullRequestOnRepo (token : String) (repo : Repository)
-    (head base title body : String) : IO String := do
-  runCmd "gh" #[
+    (head base title body : String) (labels : List String := []) : IO String := do
+  unless labels.isEmpty do
+    ensureLabels token repo labels
+  let labelArgs : Array String := (labels.flatMap fun l => ["--label", l]).toArray
+  runCmd "gh" (#[
     "pr", "create",
     "--repo", repo.toString,
     "--head", head,
     "--base", base,
     "--title", title,
     "--body", body
-  ] (env := #[("GH_TOKEN", some token)])
+  ] ++ labelArgs) (env := #[("GH_TOKEN", some token)])
 
 /--
 Fetch review threads for a pull request via the GitHub GraphQL API.

--- a/Orchestra/Listener.lean
+++ b/Orchestra/Listener.lean
@@ -162,6 +162,8 @@ structure ActionConfig where
       (e.g. `"{{pr_number}}"`) or a literal (e.g. `"69"`). When absent the
       `issue_number` template variable provided by the event source is used. -/
   issueNumber    : Option String := none
+  /-- Labels to apply automatically to every PR created via `create_pr` during this task. -/
+  prLabels       : List String   := []
 
 instance : ToJson ActionConfig where
   toJson a :=
@@ -185,6 +187,7 @@ instance : ToJson ActionConfig where
     let fields := if a.priority != 10             then fields ++ [("priority",        Json.num a.priority)] else fields
     let fields := if let some p := a.workflowPath then fields ++ [("workflow_path",  Json.str p)]          else fields
     let fields := if let some n := a.issueNumber  then fields ++ [("issue_number",   Json.str n)]          else fields
+    let fields := if !a.prLabels.isEmpty          then fields ++ [("pr_labels",      ToJson.toJson a.prLabels)] else fields
     Json.mkObj fields
 
 instance : FromJson ActionConfig where
@@ -214,8 +217,10 @@ instance : FromJson ActionConfig where
     let priority     := j.getObjValAs? Nat    "priority"      |>.toOption |>.getD 10
     let workflowPath := j.getObjValAs? String "workflow_path" |>.toOption
     let issueNumber  := j.getObjValAs? String "issue_number"  |>.toOption
+    let prLabels     := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
     return { upstream, fork, mode, promptTemplate, series, backend, model, agent, systemPrompt,
-             budget, memory, authSource, tools, readOnly, priority, workflowPath, issueNumber }
+             budget, memory, authSource, tools, readOnly, priority, workflowPath, issueNumber,
+             prLabels }
 
 -- Listener config
 
@@ -374,6 +379,7 @@ def buildQueueEntry (action : ActionConfig) (vars : List (String × String)) : I
     readOnly     := action.readOnly
     priority     := action.priority
     issueNumber
+    prLabels     := action.prLabels
   }
 
 -- GitHub helpers

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -139,6 +139,8 @@ structure QueueEntry where
   /-- Optional role name (mirrors `IOTask.role`). Used by the dispatcher to
       count per-role active tasks unambiguously. -/
   role : Option String := none
+  /-- Labels to apply automatically to every PR created via `create_pr`. -/
+  prLabels : List String := []
 
 instance : ToJson QueueEntry where
   toJson e :=
@@ -176,6 +178,7 @@ instance : ToJson QueueEntry where
     let fields := if let some p := e.projectId then fields ++ [("project_id", ToJson.toJson p)] else fields
     let fields := if let some i := e.issueId   then fields ++ [("issue_id",   ToJson.toJson i)] else fields
     let fields := if let some r := e.role      then fields ++ [("role",       Json.str r)]      else fields
+    let fields := if !e.prLabels.isEmpty       then fields ++ [("pr_labels",  ToJson.toJson e.prLabels)] else fields
     Json.mkObj fields
 
 instance : FromJson QueueEntry where
@@ -212,11 +215,12 @@ instance : FromJson QueueEntry where
     let projectId   := j.getObjValAs? ProjectId "project_id" |>.toOption
     let issueId     := j.getObjValAs? IssueId   "issue_id"   |>.toOption
     let role        := j.getObjValAs? String    "role"       |>.toOption
+    let prLabels    := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, prependPrompt, backend, model, continuesFrom, series, taskId, configPath,
              budget, memory, authSource, tools, readOnly, priority,
              concertStepKey, concertId, inputType, outputType, inputJson, outputJson,
-             issueNumber, projectId, issueId, role }
+             issueNumber, projectId, issueId, role, prLabels }
 
 -- Directories and paths
 

--- a/Orchestra/Server.lean
+++ b/Orchestra/Server.lean
@@ -53,6 +53,9 @@ structure State where
   /-- Optional auto-reviewer hook (F1). Plumbed to `Project.Tools.Env.enqueueReviewer`. -/
   enqueueReviewer : Option (Project.Project → Project.IssueId → Project.PRRef →
                             Project.ReviewerTemplate → IO (Except String String)) := none
+  /-- Labels to apply automatically to every PR created via `create_pr`.
+      Missing labels are created on the target repository before the PR is opened. -/
+  prLabels : List String := []
 
 private def log (msg : String) : IO Unit := do
   let err ← IO.getStderr
@@ -444,7 +447,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
       log s!"tool create_pr [upstream]: {state.fork}:{head} -> {state.upstream} base={base} title={repr title}"
       try
         let result ← GitHub.createPullRequest state.pat state.upstream
-          s!"{state.fork.owner}:{head}" base title body
+          s!"{state.fork.owner}:{head}" base title body state.prLabels
         log s!"tool create_pr: ok: {result.trimAscii}"
         return toolContent result
       catch e =>
@@ -458,7 +461,7 @@ private def evalToolCall (state : State) (call : ToolCall) : IO Json := do
         let jwt ← GitHub.createJWT state.appId state.privateKeyPath
         let token ← GitHub.createInstallationToken jwt state.installationId
         let result ← GitHub.createPullRequestOnRepo token state.fork
-          head base title body
+          head base title body state.prLabels
         log s!"tool create_pr: ok: {result.trimAscii}"
         return toolContent result
       catch e =>

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -364,6 +364,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
     issueId   := ioTask.issueId
     enqueueMerger   := some enqueueMergerImpl
     enqueueReviewer := some enqueueReviewerImpl
+    prLabels  := ioTask.prLabels
   }
   let (port, shutdown) ← Server.start serverState
   IO.println s!"  MCP server on port {port}"


### PR DESCRIPTION
## Summary

Implements #105: adds a `pr_labels` task configuration field that causes `create_pr` to automatically apply a list of labels to every pull request it opens.

- Add `pr_labels : List String` field to `IOTask` in `Config.lean` (parsed from `"pr_labels"` JSON key, defaults to empty)
- Add `ensureLabels` to `GitHub.lean` — iterates over the label list and creates any missing labels on the target repository with a default colour (`0075ca`); existing labels are left unchanged
- Update `createPullRequest` and `createPullRequestOnRepo` in `GitHub.lean` to accept a `labels` parameter, call `ensureLabels`, and append `--label` flags to the `gh pr create` invocation
- Add `prLabels` to `Server.State` and pass it through to both PR creation paths in `evalToolCall`
- Wire `ioTask.prLabels` into the server state in `TaskRunner.lean`

## Usage

```json
{
  "tools": ["create_pr"],
  "pr_labels": ["agent-pr", "needs-review"]
}
```

## Test plan

- [ ] Task config with `pr_labels` set: verify labels appear on the created PR
- [ ] Labels that don't exist on the repo are created automatically before the PR is opened
- [ ] Task config without `pr_labels` (or empty list): existing behaviour unchanged, no labels added
- [ ] Both `target="upstream"` and `target="fork"` paths apply labels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)