### PR TITLE
feat(triage): add deterministic triage backend for adding/removing labels

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -589,11 +589,13 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
         tools            := entry.tools
         readOnly         := entry.readOnly
         priority         := entry.priority
-        issueNumber      := entry.issueNumber
-        projectId        := entry.projectId
-        issueId          := entry.issueId
-        role             := entry.role
-        prLabels         := entry.prLabels
+        issueNumber        := entry.issueNumber
+        projectId          := entry.projectId
+        issueId            := entry.issueId
+        role               := entry.role
+        prLabels           := entry.prLabels
+        triageAddLabels    := entry.triageAddLabels
+        triageRemoveLabels := entry.triageRemoveLabels
       }
     }
     let cfg ← match entry.configPath with

--- a/Orchestra/Concert/Evaluation.lean
+++ b/Orchestra/Concert/Evaluation.lean
@@ -75,6 +75,9 @@ mutual
           tools         := spec.tools
           readOnly      := spec.readOnly
           priority      := spec.priority
+          issueNumber   := spec.issueNumber
+          triageAddLabels    := spec.triageAddLabels
+          triageRemoveLabels := spec.triageRemoveLabels
           concertStepKey := some stepKey
           concertId
           inputType     := ResultType.unit

--- a/Orchestra/Config.lean
+++ b/Orchestra/Config.lean
@@ -248,6 +248,10 @@ structure IOTask (i o : ResultType) where
   /-- Labels to automatically apply to every pull request created by `create_pr` during this task.
       Labels that do not exist on the target repository are created automatically. -/
   prLabels : List String := []
+  /-- Labels to add to the issue or PR when using the `triage` backend. -/
+  triageAddLabels : List String := []
+  /-- Labels to remove from the issue or PR when using the `triage` backend. -/
+  triageRemoveLabels : List String := []
 deriving Repr, Inhabited
 
 /-- The kind of authentication for an agent backend. -/
@@ -347,10 +351,13 @@ instance : FromJson Task where
     let projectId   := j.getObjValAs? ProjectId "project_id" |>.toOption
     let issueId     := j.getObjValAs? IssueId   "issue_id"   |>.toOption
     let role        := j.getObjValAs? String    "role"       |>.toOption
-    let prLabels    := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
+    let prLabels          := j.getObjValAs? (List String) "pr_labels"           |>.toOption |>.getD []
+    let triageAddLabels    := j.getObjValAs? (List String) "triage_add_labels"    |>.toOption |>.getD []
+    let triageRemoveLabels := j.getObjValAs? (List String) "triage_remove_labels" |>.toOption |>.getD []
     return { i, o, ioTask := { upstream, fork, mode, prompt, agent, systemPrompt, prependPrompt, backend, model,
                                 budget, memory, authSource, tools, readOnly, series, priority,
-                                issueNumber, projectId, issueId, role, prLabels } }
+                                issueNumber, projectId, issueId, role, prLabels,
+                                triageAddLabels, triageRemoveLabels } }
 
 /-- Filesystem paths to expose inside the landrun sandbox. -/
 structure SandboxPaths where

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -170,6 +170,25 @@ def getPrReviewThreads (upstream : Repository) (prNumber : Nat) (pat : String) :
   | .error e => throw (.userError s!"failed to parse GraphQL response: {e}")
   | .ok j => return j
 
+/-- Add labels to a GitHub issue or pull request. -/
+def addIssueLabels (repo : Repository) (issueNumber : Nat) (labels : List String) : IO Unit := do
+  unless labels.isEmpty do
+    let payload := Json.mkObj [("labels", Json.arr (labels.map Json.str |>.toArray))]
+    let _ ← runCmd "gh" #[
+      "api", "--method", "POST",
+      s!"/repos/{repo.owner}/{repo.name}/issues/{issueNumber}/labels",
+      "--input", "-"
+    ] (input := payload.compress)
+
+/-- Remove a label from a GitHub issue or pull request. Succeeds even if the label is not present. -/
+def removeIssueLabel (repo : Repository) (issueNumber : Nat) (label : String) : IO Unit :=
+  try
+    let _ ← runCmd "gh" #[
+      "api", "--method", "DELETE",
+      s!"/repos/{repo.owner}/{repo.name}/issues/{issueNumber}/labels/{label}"
+    ]
+  catch _ => pure ()
+
 /-- Post a comment on an issue or pull request. -/
 def createIssueComment (pat : String) (upstream : Repository) (issueNumber : Nat) (body : String) : IO String := do
   let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -180,14 +180,12 @@ def addIssueLabels (repo : Repository) (issueNumber : Nat) (labels : List String
       "--input", "-"
     ] (input := payload.compress)
 
-/-- Remove a label from a GitHub issue or pull request. Succeeds even if the label is not present. -/
-def removeIssueLabel (repo : Repository) (issueNumber : Nat) (label : String) : IO Unit :=
-  try
-    let _ ← runCmd "gh" #[
-      "api", "--method", "DELETE",
-      s!"/repos/{repo.owner}/{repo.name}/issues/{issueNumber}/labels/{label}"
-    ]
-  catch _ => pure ()
+/-- Remove a label from a GitHub issue or pull request. -/
+def removeIssueLabel (repo : Repository) (issueNumber : Nat) (label : String) : IO Unit := do
+  let _ ← runCmd "gh" #[
+    "api", "--method", "DELETE",
+    s!"/repos/{repo.owner}/{repo.name}/issues/{issueNumber}/labels/{label}"
+  ]
 
 /-- Post a comment on an issue or pull request. -/
 def createIssueComment (pat : String) (upstream : Repository) (issueNumber : Nat) (body : String) : IO String := do

--- a/Orchestra/GitHub.lean
+++ b/Orchestra/GitHub.lean
@@ -171,21 +171,23 @@ def getPrReviewThreads (upstream : Repository) (prNumber : Nat) (pat : String) :
   | .ok j => return j
 
 /-- Add labels to a GitHub issue or pull request. -/
-def addIssueLabels (repo : Repository) (issueNumber : Nat) (labels : List String) : IO Unit := do
+def addIssueLabels (pat : String) (repo : Repository) (issueNumber : Nat) (labels : List String) : IO Unit := do
   unless labels.isEmpty do
+    let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
     let payload := Json.mkObj [("labels", Json.arr (labels.map Json.str |>.toArray))]
     let _ ← runCmd "gh" #[
       "api", "--method", "POST",
       s!"/repos/{repo.owner}/{repo.name}/issues/{issueNumber}/labels",
       "--input", "-"
-    ] (input := payload.compress)
+    ] (input := payload.compress) (env := env)
 
 /-- Remove a label from a GitHub issue or pull request. -/
-def removeIssueLabel (repo : Repository) (issueNumber : Nat) (label : String) : IO Unit := do
+def removeIssueLabel (pat : String) (repo : Repository) (issueNumber : Nat) (label : String) : IO Unit := do
+  let env := if pat.isEmpty then #[] else #[("GH_TOKEN", some pat)]
   let _ ← runCmd "gh" #[
     "api", "--method", "DELETE",
     s!"/repos/{repo.owner}/{repo.name}/issues/{issueNumber}/labels/{label}"
-  ]
+  ] (env := env)
 
 /-- Post a comment on an issue or pull request. -/
 def createIssueComment (pat : String) (upstream : Repository) (issueNumber : Nat) (body : String) : IO String := do

--- a/Orchestra/Queue.lean
+++ b/Orchestra/Queue.lean
@@ -141,6 +141,10 @@ structure QueueEntry where
   role : Option String := none
   /-- Labels to apply automatically to every PR created via `create_pr`. -/
   prLabels : List String := []
+  /-- Labels to add to the issue or PR when using the `triage` backend. -/
+  triageAddLabels : List String := []
+  /-- Labels to remove from the issue or PR when using the `triage` backend. -/
+  triageRemoveLabels : List String := []
   /-- Name of the listener that created this entry, if any. -/
   listenerName : Option String := none
 
@@ -180,7 +184,9 @@ instance : ToJson QueueEntry where
     let fields := if let some p := e.projectId then fields ++ [("project_id", ToJson.toJson p)] else fields
     let fields := if let some i := e.issueId   then fields ++ [("issue_id",   ToJson.toJson i)] else fields
     let fields := if let some r := e.role         then fields ++ [("role",          Json.str r)]      else fields
-    let fields := if !e.prLabels.isEmpty          then fields ++ [("pr_labels",     ToJson.toJson e.prLabels)] else fields
+    let fields := if !e.prLabels.isEmpty          then fields ++ [("pr_labels",            ToJson.toJson e.prLabels)]         else fields
+    let fields := if !e.triageAddLabels.isEmpty   then fields ++ [("triage_add_labels",    ToJson.toJson e.triageAddLabels)]   else fields
+    let fields := if !e.triageRemoveLabels.isEmpty then fields ++ [("triage_remove_labels", ToJson.toJson e.triageRemoveLabels)] else fields
     let fields := if let some s := e.listenerName then fields ++ [("listener_name", Json.str s)]      else fields
     Json.mkObj fields
 
@@ -218,13 +224,16 @@ instance : FromJson QueueEntry where
     let projectId   := j.getObjValAs? ProjectId "project_id" |>.toOption
     let issueId     := j.getObjValAs? IssueId   "issue_id"   |>.toOption
     let role         := j.getObjValAs? String    "role"          |>.toOption
-    let prLabels     := j.getObjValAs? (List String) "pr_labels" |>.toOption |>.getD []
+    let prLabels          := j.getObjValAs? (List String) "pr_labels"           |>.toOption |>.getD []
+    let triageAddLabels    := j.getObjValAs? (List String) "triage_add_labels"    |>.toOption |>.getD []
+    let triageRemoveLabels := j.getObjValAs? (List String) "triage_remove_labels" |>.toOption |>.getD []
     let listenerName := j.getObjValAs? String "listener_name"    |>.toOption
     return { id, createdAt, status, upstream, fork, mode, prompt,
              agent, systemPrompt, prependPrompt, backend, model, continuesFrom, series, taskId, configPath,
              budget, memory, authSource, tools, readOnly, priority,
              concertStepKey, concertId, inputType, outputType, inputJson, outputJson,
-             issueNumber, projectId, issueId, role, prLabels, listenerName }
+             issueNumber, projectId, issueId, role, prLabels, triageAddLabels, triageRemoveLabels,
+             listenerName }
 
 -- Directories and paths
 

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -151,6 +151,25 @@ private def runMerger {i o : ResultType} (ioTask : IOTask i o)
           Project.saveIssue { parent with status := .open, updatedAt := now2 }
           IO.println s!"  [merger] all children of {parentId.value} completed; unblocked → open"
 
+/-- Run a triage task: add and/or remove labels on a GitHub issue or pull request.
+    Skips the entire agent / sandbox / MCP path.
+    Used when `ioTask.backend = some "triage"`. -/
+private def runTriage {i o : ResultType} (ioTask : IOTask i o)
+    (initialRecord : TaskStore.TaskRecord) : IO Unit := do
+  IO.println "  [triage] label backend"
+  let some issueNumber := ioTask.issueNumber
+    | throw (.userError "triage task missing issue_number")
+  let addLabels    := ioTask.triageAddLabels
+  let removeLabels := ioTask.triageRemoveLabels
+  if !addLabels.isEmpty then
+    IO.println s!"  [triage] adding labels {addLabels} to {ioTask.upstream}#{issueNumber}"
+    GitHub.addIssueLabels ioTask.upstream issueNumber addLabels
+  for label in removeLabels do
+    IO.println s!"  [triage] removing label '{label}' from {ioTask.upstream}#{issueNumber}"
+    GitHub.removeIssueLabel ioTask.upstream issueNumber label
+  TaskStore.saveTask { initialRecord with status := .completed }
+  IO.println s!"  [triage] done"
+
 private def sanitizeProjectName (upstream : Repository) : String :=
   s!"{upstream.owner}-{upstream.name}"
 
@@ -334,6 +353,11 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   -- clone setup with all other backends but skips the MCP server and agent.
   if ioTask.backend == some "merger" then
     runMerger ioTask repoPath initialRecord
+    return ((taskId, false), none, none)
+  -- Triage: add/remove labels on an issue or PR. Shares auth setup but skips
+  -- the repo clone, MCP server, and agent.
+  if ioTask.backend == some "triage" then
+    runTriage ioTask initialRecord
     return ((taskId, false), none, none)
   -- 3. Start MCP server (runs in this process, outside the sandbox)
   -- Resolve allowed tools: prefer explicit `tools` list, fall back to `mode` for backwards compat

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -166,7 +166,10 @@ private def runTriage {i o : ResultType} (ioTask : IOTask i o)
     GitHub.addIssueLabels ioTask.upstream issueNumber addLabels
   for label in removeLabels do
     IO.println s!"  [triage] removing label '{label}' from {ioTask.upstream}#{issueNumber}"
-    GitHub.removeIssueLabel ioTask.upstream issueNumber label
+    try
+      GitHub.removeIssueLabel ioTask.upstream issueNumber label
+    catch e =>
+      IO.eprintln s!"  [triage] failed to remove label '{label}': {e}"
   TaskStore.saveTask { initialRecord with status := .completed }
   IO.println s!"  [triage] done"
 

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -154,7 +154,7 @@ private def runMerger {i o : ResultType} (ioTask : IOTask i o)
 /-- Run a triage task: add and/or remove labels on a GitHub issue or pull request.
     Skips the entire agent / sandbox / MCP path.
     Used when `ioTask.backend = some "triage"`. -/
-private def runTriage {i o : ResultType} (ioTask : IOTask i o)
+private def runTriage {i o : ResultType} (pat : String) (ioTask : IOTask i o)
     (initialRecord : TaskStore.TaskRecord) : IO Unit := do
   IO.println "  [triage] label backend"
   let some issueNumber := ioTask.issueNumber
@@ -163,11 +163,11 @@ private def runTriage {i o : ResultType} (ioTask : IOTask i o)
   let removeLabels := ioTask.triageRemoveLabels
   if !addLabels.isEmpty then
     IO.println s!"  [triage] adding labels {addLabels} to {ioTask.upstream}#{issueNumber}"
-    GitHub.addIssueLabels ioTask.upstream issueNumber addLabels
+    GitHub.addIssueLabels pat ioTask.upstream issueNumber addLabels
   for label in removeLabels do
     IO.println s!"  [triage] removing label '{label}' from {ioTask.upstream}#{issueNumber}"
     try
-      GitHub.removeIssueLabel ioTask.upstream issueNumber label
+      GitHub.removeIssueLabel pat ioTask.upstream issueNumber label
     catch e =>
       IO.eprintln s!"  [triage] failed to remove label '{label}': {e}"
   TaskStore.saveTask { initialRecord with status := .completed }
@@ -360,7 +360,7 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   -- Triage: add/remove labels on an issue or PR. Shares auth setup but skips
   -- the repo clone, MCP server, and agent.
   if ioTask.backend == some "triage" then
-    runTriage ioTask initialRecord
+    runTriage appConfig.pat ioTask initialRecord
     return ((taskId, false), none, none)
   -- 3. Start MCP server (runs in this process, outside the sandbox)
   -- Resolve allowed tools: prefer explicit `tools` list, fall back to `mode` for backwards compat

--- a/Orchestra/Workflow.lean
+++ b/Orchestra/Workflow.lean
@@ -54,6 +54,12 @@ structure TaskSpec where
   systemPrompt  : Option String   := none
   prependPrompt : Option String   := none
   backend       : Option String   := none
+  /-- Issue or PR number to act on (required for the `triage` backend). -/
+  issueNumber   : Option Nat      := none
+  /-- Labels to add to the issue or PR when using the `triage` backend. -/
+  triageAddLabels    : List String := []
+  /-- Labels to remove from the issue or PR when using the `triage` backend. -/
+  triageRemoveLabels : List String := []
   deriving Repr
 
 /-- Specifies that a step iterates over a list. -/
@@ -163,6 +169,9 @@ private def execTask (prog : WorkflowProgram) (stepName : String) (spec : TaskSp
       agent := spec.agent, model := spec.model, readOnly := spec.readOnly
       systemPrompt := spec.systemPrompt, prependPrompt := spec.prependPrompt
       backend := spec.backend
+      issueNumber := spec.issueNumber
+      triageAddLabels := spec.triageAddLabels
+      triageRemoveLabels := spec.triageRemoveLabels
     }
     StateT.lift (run ioTask ())
   else
@@ -174,6 +183,9 @@ private def execTask (prog : WorkflowProgram) (stepName : String) (spec : TaskSp
       agent := spec.agent, model := spec.model, readOnly := spec.readOnly
       systemPrompt := spec.systemPrompt, prependPrompt := spec.prependPrompt
       backend := spec.backend
+      issueNumber := spec.issueNumber
+      triageAddLabels := spec.triageAddLabels
+      triageRemoveLabels := spec.triageRemoveLabels
     }
     let j ← StateT.lift (run ioTask ())
     modify fun (env', ctrl) =>

--- a/Orchestra/WorkflowParser.lean
+++ b/Orchestra/WorkflowParser.lean
@@ -101,6 +101,18 @@ private def parseTaskSpec (node : Node) : Except String TaskSpec := do
   let systemPrompt  := (mappingLookup pairs "system-prompt").bind  (nodeAsString · |>.toOption)
   let prependPrompt := (mappingLookup pairs "prepend-prompt").bind (nodeAsString · |>.toOption)
   let backend       := (mappingLookup pairs "backend").bind        (nodeAsString · |>.toOption)
+  let issueNumber   := (mappingLookup pairs "issue-number").bind   (nodeAsString · |>.toOption)
+                       |>.bind (·.toNat?)
+  let triageAddLabels ← match mappingLookup pairs "triage-add" with
+    | none      => pure []
+    | some node => do
+        let items ← nodeAsSeq node
+        items.toList.mapM (nodeAsString ·)
+  let triageRemoveLabels ← match mappingLookup pairs "triage-remove" with
+    | none      => pure []
+    | some node => do
+        let items ← nodeAsSeq node
+        items.toList.mapM (nodeAsString ·)
   let input ← match mappingLookup pairs "input" with
     | none      => pure []
     | some iNode => do
@@ -115,7 +127,7 @@ private def parseTaskSpec (node : Node) : Except String TaskSpec := do
           let name ← nodeAsString k
           parseOutputSpec name v
   return { agent, model, prompt, readOnly, input, output, context, upstream, fork,
-           systemPrompt, prependPrompt, backend }
+           systemPrompt, prependPrompt, backend, issueNumber, triageAddLabels, triageRemoveLabels }
 
 private def parseWriteAction (node : Node) : Except String StepAction := do
   let s ← nodeAsString node


### PR DESCRIPTION
Closes #116

## Summary

- Adds a new `triage` backend that adds and/or removes labels from a GitHub issue or pull request deterministically, without spawning an agent
- Like the `merger` backend, it reuses the GitHub App auth setup but skips the repo clone, MCP server, and sandbox
- Two new GitHub API helpers: `addIssueLabels` and `removeIssueLabel`

## Configuration

**In a concert workflow YAML file:**
```yaml
steps:
  label:
    task:
      backend: triage
      prompt: "apply triage labels"
      issue-number: 42
      triage-add: [bug, needs-review]
      triage-remove: [untriaged]
```

**In a JSON task file:**
```json
{
  "backend": "triage",
  "issue_number": 42,
  "triage_add_labels": ["bug"],
  "triage_remove_labels": ["untriaged"]
}
```