### PR TITLE
fix(listener): apply template variables to concert workflow YAML content

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -714,7 +714,8 @@ private def queueStartHandler (p : Parsed) : IO UInt32 := do
               -- Concert mode: parse the YAML, apply template vars, start a concert fiber.
               let resolvedPath := Listener.renderTemplate wfPath vars
               try
-                let yaml ← IO.FS.readFile resolvedPath
+                let rawYaml ← IO.FS.readFile resolvedPath
+                let yaml := Listener.renderTemplate rawYaml vars
                 match Workflow.WorkflowProgram.parseYaml yaml with
                 | .error e =>
                   IO.eprintln s!"  Listener '{liveCfg.name}': workflow parse error: {e}"


### PR DESCRIPTION
- When a listener triggers a concert workflow, `{{variable}}` patterns in the workflow YAML were not being substituted with listener parameters before parsing
- Fix: apply `Listener.renderTemplate` to the raw YAML content after reading the file but before passing it to `WorkflowProgram.parseYaml`

Fixes #117.