### PR TITLE
feat(gemini): add Gemini API backend for direct LLM queries in concerts

### DIFF
--- a/Orchestra/Agents/Gemini.lean
+++ b/Orchestra/Agents/Gemini.lean
@@ -1,0 +1,115 @@
+import Orchestra.Config
+import Lean.Data.Json
+
+open Lean (Json)
+
+namespace Orchestra.Gemini
+
+/-- Default Gemini model when none is specified in the task. -/
+def defaultModel : String := "gemini-2.0-flash"
+
+private def runCmd (cmd : String) (args : Array String)
+    (input : Option String := none) : IO String := do
+  let child ← IO.Process.spawn {
+    cmd, args
+    stdin  := if input.isSome then .piped else .null
+    stdout := .piped
+    stderr := .piped
+  }
+  if let some s := input then
+    let (stdinHandle, child') ← child.takeStdin
+    stdinHandle.putStr s
+    stdinHandle.flush
+    let stdout ← child'.stdout.readToEnd
+    let stderr ← child'.stderr.readToEnd
+    let code ← child'.wait
+    if code != 0 then
+      throw (.userError s!"{cmd} failed (exit {code}):\n{stderr}")
+    return stdout.trimAscii.toString
+  let stdout ← child.stdout.readToEnd
+  let stderr ← child.stderr.readToEnd
+  let code ← child.wait
+  if code != 0 then
+    throw (.userError s!"{cmd} failed (exit {code}):\n{stderr}")
+  return stdout.trimAscii.toString
+
+/-- Query the Gemini generateContent API with the given prompt and return the response text.
+    The request body is piped to curl via stdin to safely handle large prompts and special chars.
+    An optional system prompt is passed as a `system_instruction` if provided. -/
+def queryGemini (apiKey : String) (model : String) (prompt : String)
+    (systemPrompt : Option String := none) : IO String := do
+  let contentsPart := Json.arr #[Json.mkObj [
+    ("role", .str "user"),
+    ("parts", Json.arr #[Json.mkObj [("text", .str prompt)]])
+  ]]
+  let fields : List (String × Json) :=
+    match systemPrompt with
+    | none    => [("contents", contentsPart)]
+    | some sp =>
+      [ ("system_instruction", Json.mkObj
+          [("parts", Json.arr #[Json.mkObj [("text", .str sp)]])])
+      , ("contents", contentsPart) ]
+  let requestBody := Json.mkObj fields
+  let url :=
+    s!"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={apiKey}"
+  let response ← runCmd "curl"
+    #["-s", "-f", "-X", "POST",
+      "-H", "Content-Type: application/json",
+      "--data-binary", "@-",
+      url]
+    (input := some requestBody.compress)
+  match Json.parse response with
+  | .error e =>
+    throw (.userError s!"Gemini response parse error: {e}\nRaw: {response}")
+  | .ok j =>
+    if let .ok errObj := j.getObjVal? "error" then
+      let msg := errObj.getObjValAs? String "message" |>.toOption |>.getD j.compress
+      throw (.userError s!"Gemini API error: {msg}")
+    let .ok (.arr candidates) := j.getObjVal? "candidates"
+      | throw (.userError s!"Gemini response missing 'candidates': {j.compress}")
+    let some candidate := candidates[0]?
+      | throw (.userError "Gemini response has empty 'candidates' array")
+    let .ok content := candidate.getObjVal? "content"
+      | throw (.userError s!"Gemini candidate missing 'content': {candidate.compress}")
+    let .ok (.arr parts) := content.getObjVal? "parts"
+      | throw (.userError s!"Gemini content missing 'parts': {content.compress}")
+    let some part := parts[0]?
+      | throw (.userError "Gemini content has empty 'parts' array")
+    let .ok text := part.getObjValAs? String "text"
+      | throw (.userError s!"Gemini part missing 'text': {part.compress}")
+    return text
+
+/-- Resolve the Gemini API key from the application configuration.
+    Looks up the "gemini" backend in `appConfig.agentAuthConfigs` and extracts the API key,
+    following the same label-resolution rules as other backends:
+    explicit auth_source label > default_auth_source > sole configured source. -/
+def resolveApiKey (appConfig : AppConfig) (requestedLabel : Option String) : IO String := do
+  let some agentAuth := appConfig.agentAuthConfigs.find? (fun c => c.name == "gemini")
+    | throw (.userError
+        "No auth sources configured for the 'gemini' backend. \
+         Add an entry with name 'gemini' and an 'api_key' auth source to the \
+         'agents' array in your orchestra config.")
+  let label ← match requestedLabel with
+    | some l => pure l
+    | none   =>
+      match agentAuth.defaultAuthSource with
+      | some d => pure d
+      | none   =>
+        if agentAuth.authSources.size == 1 then
+          pure agentAuth.authSources[0]!.label
+        else
+          throw (.userError
+            "Multiple auth sources configured for the 'gemini' backend. \
+             Specify one via the 'auth_source' field in the task.")
+  let some src := agentAuth.authSources.find? (fun s => s.label == label)
+    | throw (.userError
+        s!"Auth source '{label}' not found for the 'gemini' backend. \
+           Available: {", ".intercalate (agentAuth.authSources.toList.map (·.label))}")
+  match src.kind with
+  | .apiKey key _ => return key
+  | .oauthToken _ =>
+    throw (.userError
+      s!"Auth source '{label}' for the 'gemini' backend uses an OAuth token, \
+         but Gemini requires an 'api_key' auth source.")
+
+end Orchestra.Gemini

--- a/Orchestra/TaskRunner.lean
+++ b/Orchestra/TaskRunner.lean
@@ -1,6 +1,7 @@
 import Orchestra.Config
 import Orchestra.AgentDef
 import Orchestra.Agents.Claude
+import Orchestra.Agents.Gemini
 import Orchestra.Agents.Opencode
 import Orchestra.Agents.Pi
 import Orchestra.Agents.Vibe
@@ -173,6 +174,26 @@ private def runTriage {i o : ResultType} (pat : String) (ioTask : IOTask i o)
   TaskStore.saveTask { initialRecord with status := .completed }
   IO.println s!"  [triage] done"
 
+/-- Run a Gemini query task: resolve the API key from auth sources, call the Gemini
+    generateContent API with the task prompt, and record the text response as the task output.
+    Skips the entire sandbox / MCP server / repo-clone path. -/
+private def runGeminiQuery {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
+    (initialRecord : TaskStore.TaskRecord) : IO (Option Lean.Json) := do
+  IO.println "  [gemini] external LLM query backend"
+  let apiKey ← Gemini.resolveApiKey appConfig ioTask.authSource
+  let model := ioTask.model.getD Gemini.defaultModel
+  IO.println s!"  [gemini] model: {model}"
+  let systemPrompt ← loadSystemPrompt ioTask.systemPrompt
+  let response ← try
+    Gemini.queryGemini apiKey model ioTask.prompt systemPrompt
+  catch e =>
+    IO.eprintln s!"  [gemini] API query failed: {e}"
+    TaskStore.saveTask { initialRecord with status := .failed }
+    throw e
+  TaskStore.saveTask { initialRecord with status := .completed }
+  IO.println "  [gemini] done"
+  return some (.str response)
+
 private def sanitizeProjectName (upstream : Repository) : String :=
   s!"{upstream.owner}-{upstream.name}"
 
@@ -338,6 +359,17 @@ def runIOTask {i o : ResultType} (appConfig : AppConfig) (ioTask : IOTask i o)
   IO.println "  Prompt:"
   for line in ioTask.prompt.splitOn "\n" do
     IO.println s!"    {line}"
+  -- Gemini: query the Gemini API directly. Skips GitHub auth, repo clone, sandbox, and MCP server.
+  if ioTask.backend == some "gemini" then
+    let outputJson ← runGeminiQuery appConfig ioTask initialRecord
+    let typedOutput : Option o.Type ← match outputJson with
+      | none   => pure none
+      | some j => match ResultType.valueFromJson o j with
+        | .ok v    => pure (some v)
+        | .error e =>
+          IO.eprintln s!"  [gemini] Warning: failed to deserialize output: {e}"
+          pure none
+    return ((taskId, false), typedOutput, outputJson)
   -- 1. Create GitHub App token
   IO.println "  Creating GitHub App token..."
   let jwt ← GitHub.createJWT appConfig.appId appConfig.privateKeyPath


### PR DESCRIPTION
## Summary

- Add `Orchestra/Agents/Gemini.lean` with `queryGemini` (calls the Gemini `generateContent` REST endpoint via curl, piping the JSON body through stdin for safe handling of large prompts) and `resolveApiKey` (standard auth-source label resolution for the `"gemini"` backend)
- Add `runGeminiQuery` in `TaskRunner.lean`, dispatched before the GitHub-auth / repo-clone / MCP-server path — tasks with `backend = "gemini"` skip all sandbox machinery and call the Gemini API directly
- The model's text reply is stored as the task output (`ResultType.string`), making it directly consumable as a typed input to downstream concert steps

## Configuration

Add an entry to the `agents` array in `~/.config/orchestra/config.json`:

```json
{
  "agents": [
    {
      "name": "gemini",
      "auth_sources": [
        { "label": "default", "api_key": "AIza..." }
      ]
    }
  ]
}
```

## Task example

```json
{
  "upstream": "owner/repo",
  "fork": "owner/repo",
  "mode": "fork",
  "backend": "gemini",
  "model": "gemini-2.0-flash",
  "output_type": "string",
  "prompt": "Summarise the following issue: ..."
}
```

## Test plan

- [ ] Build passes (`lake build`)
- [ ] Task with `backend: "gemini"` and a valid API key produces the LLM response as the task output
- [ ] Task with `backend: "gemini"` and an invalid API key fails with a clear error message and marks the task as `.failed`
- [ ] Auth source label resolution follows the same rules as other backends (explicit label, default, sole source)
- [ ] System prompt file is loaded and passed as `system_instruction` when `system_prompt` is set

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)