### PR TITLE
fix(Repo): configure gh auth before git fetch upstream

### DIFF
--- a/Orchestra/Repo.lean
+++ b/Orchestra/Repo.lean
@@ -109,11 +109,11 @@ def ensureCloned (fork upstream : Repository) (interactive : Bool := true) : IO 
     let remotes₃ ← runGit #["remote"] repoPath
     if !(remotes₃.splitOn "\n" |>.any (· == "upstream")) then
       runGit' #["remote", "add", "upstream", githubUrl upstream] repoPath
+  -- Ensure gh credentials are wired into git for authenticated operations
+  runGh' #["auth", "setup-git"] none
   -- Fetch upstream to keep remote tracking branches up to date
   IO.println "  Fetching upstream..."
   runGit' #["fetch", "upstream"] repoPath
-  -- Ensure gh credentials are wired into git for authenticated pushes
-  runGh' #["auth", "setup-git"] none
   return repoPath
 
 /-- Remove all cloned repositories. -/


### PR DESCRIPTION
The ensureCloned function called `git fetch upstream` before `gh auth setup-git`, meaning git had no credentials configured when trying to fetch from the upstream HTTPS remote. This caused repeated authentication failures:

  fatal: Authentication failed for 'https://github.com/...

Move `gh auth setup-git` before `git fetch upstream` so credentials are wired into git before any authenticated operations.